### PR TITLE
[Hack] Prefill Disaggregation Prototype

### DIFF
--- a/benchmarks/benchmark_throughput_async.py
+++ b/benchmarks/benchmark_throughput_async.py
@@ -178,7 +178,7 @@ def main(args: argparse.Namespace):
           f"{total_num_tokens / elapsed_time:.2f} tokens/s")
 
 
-def get_parser():
+def get_parsed_args():
     parser = argparse.ArgumentParser(description="Benchmark the throughput.")
     parser.add_argument("--backend",
                         type=str,
@@ -270,10 +270,9 @@ def get_parser():
         if args.tokenizer != args.model:
             raise ValueError("Tokenizer must be the same as the model for MII "
                              "backend.")
-    return parser
+    return args
 
 
 if __name__ == "__main__":
-    parser = get_parser()
-    args = parser.parse_args()
+    args = get_parsed_args()
     main(args)

--- a/benchmarks/benchmark_throughput_async.py
+++ b/benchmarks/benchmark_throughput_async.py
@@ -191,7 +191,7 @@ def get_parsed_args():
                         type=int,
                         default=None,
                         help="Output length for each request. Overrides the "
-                             "output length from the dataset.")
+                        "output length from the dataset.")
     parser.add_argument("--model", type=str, default="facebook/opt-125m")
     parser.add_argument("--tokenizer", type=str, default=None)
     parser.add_argument('--quantization',
@@ -221,16 +221,16 @@ def get_parsed_args():
         type=int,
         default=None,
         help='Maximum length of a sequence (including prompt and output). '
-             'If None, will be derived from the model.')
+        'If None, will be derived from the model.')
     parser.add_argument(
         '--dtype',
         type=str,
         default='auto',
         choices=['auto', 'half', 'float16', 'bfloat16', 'float', 'float32'],
         help='data type for model weights and activations. '
-             'The "auto" option will use FP16 precision '
-             'for FP32 and FP16 models, and BF16 precision '
-             'for BF16 models.')
+        'The "auto" option will use FP16 precision '
+        'for FP32 and FP16 models, and BF16 precision '
+        'for BF16 models.')
     parser.add_argument("--enforce-eager",
                         action="store_true",
                         help="enforce eager execution")

--- a/benchmarks/benchmark_throughput_async.py
+++ b/benchmarks/benchmark_throughput_async.py
@@ -1,4 +1,4 @@
-"""Benchmark offline inference throughput."""
+"""Benchmark offline inference throughput for DistServe."""
 import argparse
 import argparse
 import asyncio

--- a/benchmarks/benchmark_throughput_async.py
+++ b/benchmarks/benchmark_throughput_async.py
@@ -209,7 +209,7 @@ def get_parsed_args():
                         type=int,
                         default=None,
                         help="Output length for each request. Overrides the "
-                             "output length from the dataset.")
+                        "output length from the dataset.")
     parser.add_argument("--model", type=str, default="facebook/opt-125m")
     parser.add_argument("--tokenizer", type=str, default=None)
     parser.add_argument('--quantization',
@@ -239,16 +239,16 @@ def get_parsed_args():
         type=int,
         default=None,
         help='Maximum length of a sequence (including prompt and output). '
-             'If None, will be derived from the model.')
+        'If None, will be derived from the model.')
     parser.add_argument(
         '--dtype',
         type=str,
         default='auto',
         choices=['auto', 'half', 'float16', 'bfloat16', 'float', 'float32'],
         help='data type for model weights and activations. '
-             'The "auto" option will use FP16 precision '
-             'for FP32 and FP16 models, and BF16 precision '
-             'for BF16 models.')
+        'The "auto" option will use FP16 precision '
+        'for FP32 and FP16 models, and BF16 precision '
+        'for BF16 models.')
     parser.add_argument("--enforce-eager",
                         action="store_true",
                         help="enforce eager execution")

--- a/benchmarks/benchmark_throughput_async.py
+++ b/benchmarks/benchmark_throughput_async.py
@@ -142,7 +142,6 @@ def run_vllm(
     end = time.perf_counter()
 
     import pandas as pd
-    "(start_time, end_time, duration, task_name)"
     df = pd.DataFrame(
         engine.engine.event_logging,
         columns=["start_time", "end_time", "duration", "task_name"],

--- a/benchmarks/benchmark_throughput_async.py
+++ b/benchmarks/benchmark_throughput_async.py
@@ -141,15 +141,18 @@ def run_vllm(
     results = asyncio.run(drain_all_streams())
     end = time.perf_counter()
 
-    import pandas as pd
-    df = pd.DataFrame(
-        engine.engine.event_logging,
-        columns=["start_time", "end_time", "duration", "task_name"],
-    )
-    # Store the event logging.
-    df.to_csv("event_logging.csv", index=False)
-    # also in markdown
-    df.to_markdown("event_logging.md", index=False)
+    try:
+        import pandas as pd
+        df = pd.DataFrame(
+            engine.engine.event_logging,
+            columns=["start_time", "end_time", "duration", "task_name"],
+        )
+        # Store the event logging.
+        df.to_csv("event_logging.csv", index=False)
+        # also in markdown
+        df.to_markdown("event_logging.md", index=False)
+    except:
+        pass
 
     return end - start
 
@@ -206,7 +209,7 @@ def get_parsed_args():
                         type=int,
                         default=None,
                         help="Output length for each request. Overrides the "
-                        "output length from the dataset.")
+                             "output length from the dataset.")
     parser.add_argument("--model", type=str, default="facebook/opt-125m")
     parser.add_argument("--tokenizer", type=str, default=None)
     parser.add_argument('--quantization',
@@ -236,16 +239,16 @@ def get_parsed_args():
         type=int,
         default=None,
         help='Maximum length of a sequence (including prompt and output). '
-        'If None, will be derived from the model.')
+             'If None, will be derived from the model.')
     parser.add_argument(
         '--dtype',
         type=str,
         default='auto',
         choices=['auto', 'half', 'float16', 'bfloat16', 'float', 'float32'],
         help='data type for model weights and activations. '
-        'The "auto" option will use FP16 precision '
-        'for FP32 and FP16 models, and BF16 precision '
-        'for BF16 models.')
+             'The "auto" option will use FP16 precision '
+             'for FP32 and FP16 models, and BF16 precision '
+             'for BF16 models.')
     parser.add_argument("--enforce-eager",
                         action="store_true",
                         help="enforce eager execution")

--- a/benchmarks/benchmark_throughput_async.py
+++ b/benchmarks/benchmark_throughput_async.py
@@ -99,6 +99,9 @@ def run_vllm(
 
     # Add the requests to the engine.
 
+    num_requests = len(requests)
+    pbar = tqdm(total=num_requests, desc="Processed prompts")
+
     async def drain_stream(prompt, output_len, request_id):
         result = []
         sampling_params = SamplingParams(
@@ -112,6 +115,7 @@ def run_vllm(
         stream = engine.generate(prompt, sampling_params, request_id)
         async for output in stream:
             result.append(output)
+        pbar.update(1)
         return result
 
     async def drain_all_streams():
@@ -124,6 +128,7 @@ def run_vllm(
             task = asyncio.create_task(coro)
             result.append(task)
             request_id += 1
+        # Gather the first completed
         results = await asyncio.gather(*result)
         event_loop_task.cancel()
         return results

--- a/benchmarks/benchmark_throughput_async.py
+++ b/benchmarks/benchmark_throughput_async.py
@@ -1,0 +1,263 @@
+"""Benchmark offline inference throughput."""
+import argparse
+import argparse
+import json
+import random
+import time
+from typing import List, Optional, Tuple
+
+import torch
+from transformers import (AutoModelForCausalLM, AutoTokenizer,
+                          PreTrainedTokenizerBase)
+from tqdm import tqdm
+
+from vllm import AsyncLLMEngine, RequestOutput
+
+
+def sample_requests(
+    dataset_path: str,
+    num_requests: int,
+    tokenizer: PreTrainedTokenizerBase,
+    fixed_output_len: Optional[int],
+) -> List[Tuple[str, int, int]]:
+    if fixed_output_len is not None and fixed_output_len < 4:
+        raise ValueError("output_len too small")
+
+    # Load the dataset.
+    with open(dataset_path) as f:
+        dataset = json.load(f)
+    # Filter out the conversations with less than 2 turns.
+    dataset = [data for data in dataset if len(data["conversations"]) >= 2]
+    # Only keep the first two turns of each conversation.
+    dataset = [(data["conversations"][0]["value"],
+                data["conversations"][1]["value"]) for data in dataset]
+
+    # Tokenize the prompts and completions.
+    prompts = [prompt for prompt, _ in dataset]
+    prompt_token_ids = tokenizer(prompts).input_ids
+    completions = [completion for _, completion in dataset]
+    completion_token_ids = tokenizer(completions).input_ids
+    tokenized_dataset = []
+    for i in range(len(dataset)):
+        output_len = len(completion_token_ids[i])
+        if fixed_output_len is not None:
+            output_len = fixed_output_len
+        tokenized_dataset.append((prompts[i], prompt_token_ids[i], output_len))
+
+    # Filter out too long sequences.
+    filtered_dataset: List[Tuple[str, int, int]] = []
+    for prompt, prompt_token_ids, output_len in tokenized_dataset:
+        prompt_len = len(prompt_token_ids)
+        if prompt_len < 4 or output_len < 4:
+            # Prune too short sequences.
+            continue
+        if prompt_len > 1024 or prompt_len + output_len > 2048:
+            # Prune too long sequences.
+            continue
+        filtered_dataset.append((prompt, prompt_len, output_len))
+
+    # Sample the requests.
+    sampled_requests = random.sample(filtered_dataset, num_requests)
+    return sampled_requests
+
+
+def run_vllm(
+    requests: List[Tuple[str, int, int]],
+    model: str,
+    tokenizer: str,
+    quantization: Optional[str],
+    tensor_parallel_size: int,
+    seed: int,
+    n: int,
+    use_beam_search: bool,
+    trust_remote_code: bool,
+    dtype: str,
+    max_model_len: Optional[int],
+    enforce_eager: bool,
+) -> float:
+    from vllm import LLM, SamplingParams
+    engine_args = LLM(
+        model=model,
+        tokenizer=tokenizer,
+        quantization=quantization,
+        tensor_parallel_size=tensor_parallel_size,
+        seed=seed,
+        trust_remote_code=trust_remote_code,
+        dtype=dtype,
+        max_model_len=max_model_len,
+        enforce_eager=enforce_eager,
+        # Trick arguments to get engine to do DistServe.
+        is_disaggregate=True,
+        pipeline_parallel_size=2,
+        is_dummy_llm=True,
+    ).engine_args
+
+    engine = AsyncLLMEngine.from_engine_args(engine_args)
+
+    # FIXME: Hack - this can be within DistLLM.
+
+    # Add the requests to the engine.
+    request_counter = 0
+    prefix_pos = 0
+
+    streams = []
+    for prompt, _, output_len in requests:
+        sampling_params = SamplingParams(
+            n=n,
+            temperature=0.0 if use_beam_search else 1.0,
+            top_p=1.0,
+            use_beam_search=use_beam_search,
+            ignore_eos=True,
+            max_tokens=output_len,
+        )
+        arrival_time = time.time()
+        prompt_token_ids = engine.engine.tokenizer(prompt).input_ids
+        stream = engine.engine._request_tracker.add_request(
+            request_counter,
+            prompt=prompt,
+            sampling_params=sampling_params,
+            prompt_token_ids=prompt_token_ids,
+            arrival_time=arrival_time,
+            prefix_pos=prefix_pos)
+        streams.append(stream)
+        request_counter += 1
+
+    start = time.perf_counter()
+    engine.start_background_loop()
+    end = time.perf_counter()
+    return end - start
+
+
+def main(args: argparse.Namespace):
+    print(args)
+    random.seed(args.seed)
+
+    # Sample the requests.
+    tokenizer = AutoTokenizer.from_pretrained(
+        args.tokenizer, trust_remote_code=args.trust_remote_code)
+    if args.dataset is None:
+        # Synthesize a prompt with the given input length.
+        prompt = "hi" * (args.input_len - 1)
+        requests = [(prompt, args.input_len, args.output_len)
+                    for _ in range(args.num_prompts)]
+    else:
+        requests = sample_requests(args.dataset, args.num_prompts, tokenizer,
+                                   args.output_len)
+
+    if args.backend == "vllm":
+        elapsed_time = run_vllm(requests, args.model, args.tokenizer,
+                                args.quantization, args.tensor_parallel_size,
+                                args.seed, args.n, args.use_beam_search,
+                                args.trust_remote_code, args.dtype,
+                                args.max_model_len, args.enforce_eager)
+    elif args.backend == "hf":
+        raise NotImplementedError
+    elif args.backend == "mii":
+        raise NotImplementedError
+    else:
+        raise ValueError(f"Unknown backend: {args.backend}")
+    total_num_tokens = sum(prompt_len + output_len
+                           for _, prompt_len, output_len in requests)
+    print(f"Throughput: {len(requests) / elapsed_time:.2f} requests/s, "
+          f"{total_num_tokens / elapsed_time:.2f} tokens/s")
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(description="Benchmark the throughput.")
+    parser.add_argument("--backend",
+                        type=str,
+                        choices=["vllm", "hf", "mii"],
+                        default="vllm")
+    parser.add_argument("--dataset",
+                        type=str,
+                        default=None,
+                        help="Path to the dataset.")
+    parser.add_argument("--input-len",
+                        type=int,
+                        default=None,
+                        help="Input prompt length for each request")
+    parser.add_argument("--output-len",
+                        type=int,
+                        default=None,
+                        help="Output length for each request. Overrides the "
+                             "output length from the dataset.")
+    parser.add_argument("--model", type=str, default="facebook/opt-125m")
+    parser.add_argument("--tokenizer", type=str, default=None)
+    parser.add_argument('--quantization',
+                        '-q',
+                        choices=['awq', 'gptq', 'squeezellm', None],
+                        default=None)
+    parser.add_argument("--tensor-parallel-size", "-tp", type=int, default=1)
+    parser.add_argument("--n",
+                        type=int,
+                        default=1,
+                        help="Number of generated sequences per prompt.")
+    parser.add_argument("--use-beam-search", action="store_true")
+    parser.add_argument("--num-prompts",
+                        type=int,
+                        default=1000,
+                        help="Number of prompts to process.")
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--hf-max-batch-size",
+                        type=int,
+                        default=None,
+                        help="Maximum batch size for HF backend.")
+    parser.add_argument('--trust-remote-code',
+                        action='store_true',
+                        help='trust remote code from huggingface')
+    parser.add_argument(
+        '--max-model-len',
+        type=int,
+        default=None,
+        help='Maximum length of a sequence (including prompt and output). '
+             'If None, will be derived from the model.')
+    parser.add_argument(
+        '--dtype',
+        type=str,
+        default='auto',
+        choices=['auto', 'half', 'float16', 'bfloat16', 'float', 'float32'],
+        help='data type for model weights and activations. '
+             'The "auto" option will use FP16 precision '
+             'for FP32 and FP16 models, and BF16 precision '
+             'for BF16 models.')
+    parser.add_argument("--enforce-eager",
+                        action="store_true",
+                        help="enforce eager execution")
+    args = parser.parse_args()
+    if args.tokenizer is None:
+        args.tokenizer = args.model
+    if args.dataset is None:
+        assert args.input_len is not None
+        assert args.output_len is not None
+    else:
+        assert args.input_len is None
+
+    if args.backend == "vllm":
+        if args.hf_max_batch_size is not None:
+            raise ValueError("HF max batch size is only for HF backend.")
+    elif args.backend == "hf":
+        if args.hf_max_batch_size is None:
+            raise ValueError("HF max batch size is required for HF backend.")
+        if args.quantization is not None:
+            raise ValueError("Quantization is only for vLLM backend.")
+    elif args.backend == "mii":
+        if args.dtype != "auto":
+            raise ValueError("dtype must be auto for MII backend.")
+        if args.n != 1:
+            raise ValueError("n must be 1 for MII backend.")
+        if args.use_beam_search:
+            raise ValueError("Beam search is not supported for MII backend.")
+        if args.quantization is not None:
+            raise ValueError("Quantization is only for vLLM backend.")
+        if args.hf_max_batch_size is not None:
+            raise ValueError("HF max batch size is only for HF backend.")
+        if args.tokenizer != args.model:
+            raise ValueError("Tokenizer must be the same as the model for MII "
+                             "backend.")
+    return parser
+
+
+if __name__ == "__main__":
+    parser = get_parser()
+    args = parser.parse_args()
+    main(args)

--- a/csrc/cache.h
+++ b/csrc/cache.h
@@ -28,3 +28,32 @@ void gather_cached_kv(
   torch::Tensor& key_cache,
   torch::Tensor& value_cache,
   torch::Tensor& slot_mapping);
+
+std::vector<int64_t> get_ipc_mem_handle(torch::Tensor tensor);
+
+bool register_ipc_mem_handle(
+	std::vector<int64_t> k_cache_handle_vec,
+	std::vector<int64_t> v_cache_handle_vec,
+	int64_t num_layers,
+	int64_t num_heads,
+	const std::vector<int64_t> &context_parallel_config,
+	const std::vector<int64_t> &decoding_parallel_config
+);
+
+void migrate_blocks(
+	const int64_t context_pp_size,
+	const int64_t context_tp_size,
+
+	const std::vector<int64_t> &context_block_indexes,
+
+	const int64_t decoding_pp_size,
+	const int64_t decoding_tp_size,
+
+	const int64_t decoding_pp_rank,
+	const int64_t decoding_tp_rank,
+
+	const std::vector<int64_t> &decoding_block_indexes,
+
+	torch::Tensor decoding_worker_k_cache,
+	torch::Tensor decoding_worker_v_cache
+);

--- a/csrc/cache.h
+++ b/csrc/cache.h
@@ -34,6 +34,7 @@ std::vector<int64_t> get_ipc_mem_handle(torch::Tensor tensor);
 bool register_ipc_mem_handle(
 	std::vector<int64_t> k_cache_handle_vec,
 	std::vector<int64_t> v_cache_handle_vec,
+    int64_t layer_id,
 	int64_t num_layers,
 	int64_t num_heads,
 	const std::vector<int64_t> &context_parallel_config,

--- a/csrc/cache.h
+++ b/csrc/cache.h
@@ -54,6 +54,24 @@ void migrate_blocks(
 
 	const std::vector<int64_t> &decoding_block_indexes,
 
+	std::vector<torch::Tensor>& decoding_worker_k_caches,
+	std::vector<torch::Tensor>& decoding_worker_v_caches
+);
+
+void migrate_blocks__block_contiguous(
+	const int64_t context_pp_size,
+	const int64_t context_tp_size,
+
+	const std::vector<int64_t> &context_block_indexes,
+
+	const int64_t decoding_pp_size,
+	const int64_t decoding_tp_size,
+
+	const int64_t decoding_pp_rank,
+	const int64_t decoding_tp_rank,
+
+	const std::vector<int64_t> &decoding_block_indexes,
+
 	torch::Tensor decoding_worker_k_cache,
 	torch::Tensor decoding_worker_v_cache
 );

--- a/csrc/cache.h
+++ b/csrc/cache.h
@@ -42,21 +42,19 @@ bool register_ipc_mem_handle(
 );
 
 void migrate_blocks(
-	const int64_t context_pp_size,
-	const int64_t context_tp_size,
+	const int64_t num_layers,
+    const int64_t num_gpu_blocks,
+    const int64_t num_heads,
+    const int64_t head_size,
+    const int64_t block_size,
+    const int64_t x, // (x = 16 // element_size)
+    const int64_t decode_rank,
 
-	const std::vector<int64_t> &context_block_indexes,
+    const std::vector<int64_t> &context_block_indexes,
+    const std::vector<int64_t> &decoding_block_indexes,
 
-	const int64_t decoding_pp_size,
-	const int64_t decoding_tp_size,
-
-	const int64_t decoding_pp_rank,
-	const int64_t decoding_tp_rank,
-
-	const std::vector<int64_t> &decoding_block_indexes,
-
-	std::vector<torch::Tensor>& decoding_worker_k_caches,
-	std::vector<torch::Tensor>& decoding_worker_v_caches
+    std::vector<torch::Tensor> &k_cache,
+    std::vector<torch::Tensor> &v_cache,
 );
 
 void migrate_blocks__block_contiguous(

--- a/csrc/cache.h
+++ b/csrc/cache.h
@@ -54,7 +54,7 @@ void migrate_blocks(
     const std::vector<int64_t> &decoding_block_indexes,
 
     std::vector<torch::Tensor> &k_cache,
-    std::vector<torch::Tensor> &v_cache,
+    std::vector<torch::Tensor> &v_cache
 );
 
 void migrate_blocks__block_contiguous(

--- a/csrc/cache_kernels.cu
+++ b/csrc/cache_kernels.cu
@@ -569,7 +569,7 @@ void migrate_blocks(
     const std::vector<int64_t> &decoding_block_indexes,
 
     std::vector<torch::Tensor> &k_cache,
-    std::vector<torch::Tensor> &v_cache,
+    std::vector<torch::Tensor> &v_cache
 )
 {
     cudaStream_t stream = at::cuda::getCurrentCUDAStream();

--- a/csrc/cache_kernels.cu
+++ b/csrc/cache_kernels.cu
@@ -678,7 +678,7 @@ void migrate_blocks(
                 );
                 decoding_worker_base_ptr += INDEX_4D(
                     num_blocks, num_heads, head_size, block_size,
-                    decoding_block_index, 0, 0, 0,
+                    decoding_block_index, 0, 0, 0
                 );
 
                 const size_t bytes_to_copy = num_heads * head_size * block_size;

--- a/csrc/cache_kernels.cu
+++ b/csrc/cache_kernels.cu
@@ -623,16 +623,13 @@ void migrate_blocks(
 
 
 
+                // dim: (num_blocks, num_heads, head_size // x, block_size, x)
                 context_worker_base_ptr += INDEX_5D(
-                    // dim: (num_blocks, num_heads, head_size // x, block_size, x)
-                    num_blocks, num_heads, head_size_by_x, block_size, x
-                    // offset
+                    num_blocks, num_heads, head_size_by_x, block_size, x,
                     context_block_index, 0, 0, 0, 0
                 );
                 decoding_worker_base_ptr += INDEX_5D(
-                    // dim: (num_blocks, num_heads, head_size // x, block_size, x)
-                    num_blocks, num_heads, head_size_by_x, block_size, x
-                    // offset
+                    num_blocks, num_heads, head_size_by_x, block_size, x,
                     decoding_block_index, 0, 0, 0, 0
                 );
 
@@ -674,16 +671,13 @@ void migrate_blocks(
                 char* decoding_worker_base_ptr = (char*) decoding_worker_v_caches[num_layers].data_ptr();
 
 
+                // dim: (num_blocks, num_heads, head_size, block_size)
                 context_worker_base_ptr += INDEX_4D(
-                    // dim: (num_blocks, num_heads, head_size, block_size)
                     num_blocks, num_heads, head_size, block_size,
-                    // offset
                     context_block_index, 0, 0, 0
                 );
                 decoding_worker_base_ptr += INDEX_4D(
-                    // dim: (num_blocks, num_heads, head_size, block_size)
                     num_blocks, num_heads, head_size, block_size,
-                    // offset
                     decoding_block_index, 0, 0, 0,
                 );
 

--- a/csrc/cache_kernels.cu
+++ b/csrc/cache_kernels.cu
@@ -5,6 +5,10 @@
 #include "cuda_compat.h"
 #include "dispatch_utils.h"
 
+#include <cstdio>
+#include <cuda_runtime_api.h>
+
+
 #include <algorithm>
 #include <cassert>
 #include <map>
@@ -390,4 +394,236 @@ void gather_cached_kv(
         block_size,
         x);
     });
+}
+
+static std::vector<int64_t> cudaIpcMemHandle2Bytes(const cudaIpcMemHandle_t &handle) {
+	std::vector<int64_t> result;
+	for (size_t i = 0; i < sizeof(handle); ++i) {
+		result.push_back(((uint8_t*) &handle)[i]);
+	}
+	return result;
+}
+
+static cudaIpcMemHandle_t bytes2CudaIpcMemHandle(const std::vector<int64_t> &bytes) {
+	assert_whenever(bytes.size() == sizeof(cudaIpcMemHandle_t));
+	cudaIpcMemHandle_t result;
+	for (size_t i = 0; i < sizeof(result); ++i) {
+		((uint8_t*) &result)[i] = bytes[i];
+	}
+	return result;
+}
+
+
+#define CUDA_CHECK(status)                                              \
+  {                                                                     \
+    cudaError_t error = status;                                         \
+    if (error != cudaSuccess) {                                         \
+      std::cerr << "Got bad cuda status: " << cudaGetErrorString(error) \
+                << " at line: " << __LINE__ << std::endl;               \
+      exit(EXIT_FAILURE);                                               \
+    }                                                                   \
+  }
+
+/*
+get_ipc_mem_handle: Get the IPC memory handle of a tensor
+The returned handle can be used to open the tensor in another process.
+*/
+std::vector<int64_t> get_ipc_mem_handle(torch::Tensor tensor) {
+	cudaIpcMemHandle_t handle;
+	CUDA_CHECK(cudaIpcGetMemHandle(&handle, tensor.data_ptr()));
+	return cudaIpcMemHandle2Bytes(handle);
+}
+
+
+/*
+register_ipc_mem_handle: Register an IPC memory handle
+
+This function receives a IPC memory handle and the context worker's info
+(context_pp_rank and context_tp_rank) that the handle belongs to, then
+it checks whether it needs to register the handle (i.e. whether the k/v range
+it needs overlaps with the k/v range that the context worker calculates). If
+the answer is YES, register it and note down its local address.
+
+Return true if the handle is registered, false otherwise.
+*/
+static constexpr int64_t MAX_PARALLEL_HASH = 4096;	// Assume there are at most 64 pp stages and 64 tp stages
+static void* context_worker_k_cache_addr[MAX_PARALLEL_HASH];
+static void* context_worker_v_cache_addr[MAX_PARALLEL_HASH];
+bool register_ipc_mem_handle(
+	std::vector<int64_t> k_cache_handle_vec,
+	std::vector<int64_t> v_cache_handle_vec,
+	int64_t num_layers,
+	int64_t num_heads,
+	const std::vector<int64_t> &context_parallel_config,	// Generated via ParallelConfig.to_list()
+	const std::vector<int64_t> &decoding_parallel_config
+) {
+	// Convert the handles to cudaIpcMemHandle_t
+	const cudaIpcMemHandle_t k_cache_handle = bytes2CudaIpcMemHandle(k_cache_handle_vec);
+	const cudaIpcMemHandle_t v_cache_handle = bytes2CudaIpcMemHandle(v_cache_handle_vec);
+
+	// First we check whether the two k/v cache area overlaps
+	const int64_t context_tp_size = context_parallel_config[0];
+	const int64_t context_tp_rank = context_parallel_config[1];
+	const int64_t context_pp_size = context_parallel_config[2];
+	const int64_t context_pp_rank = context_parallel_config[3];
+	const int64_t decoding_tp_size = decoding_parallel_config[0];
+	const int64_t decoding_tp_rank = decoding_parallel_config[1];
+	const int64_t decoding_pp_size = decoding_parallel_config[2];
+	const int64_t decoding_pp_rank = decoding_parallel_config[3];
+
+	const int64_t layers_per_context_worker = num_layers / context_pp_size;
+	const int64_t heads_per_context_worker = num_heads / context_tp_size;
+	const int64_t layers_per_decoding_worker = num_layers / decoding_pp_size;
+	const int64_t heads_per_decoding_worker = num_heads / decoding_tp_size;
+
+	const int64_t context_start_layer = context_pp_rank * layers_per_context_worker;
+	const int64_t context_end_layer = context_start_layer + layers_per_context_worker;
+	const int64_t context_start_head = context_tp_rank * heads_per_context_worker;
+	const int64_t context_end_head = context_start_head + heads_per_context_worker;
+
+	const int64_t decoding_start_layer = decoding_pp_rank * layers_per_decoding_worker;
+	const int64_t decoding_end_layer = decoding_start_layer + layers_per_decoding_worker;
+	const int64_t decoding_start_head = decoding_tp_rank * heads_per_decoding_worker;
+	const int64_t decoding_end_head = decoding_start_head + heads_per_decoding_worker;
+
+	if (context_end_layer <= decoding_start_layer || context_start_layer >= decoding_end_layer ||
+		context_end_head <= decoding_start_head || context_start_head >= decoding_end_head) {
+		// No overlap
+		return false;
+	} else {
+		// Overlap
+		// Register the handle
+		const int64_t context_worker_hash = (context_pp_rank<<6) + context_tp_rank;
+		CUDA_CHECK(cudaIpcOpenMemHandle(&context_worker_k_cache_addr[context_worker_hash], k_cache_handle, cudaIpcMemLazyEnablePeerAccess));
+		CUDA_CHECK(cudaIpcOpenMemHandle(&context_worker_v_cache_addr[context_worker_hash], v_cache_handle, cudaIpcMemLazyEnablePeerAccess));
+		return true;
+	}
+}
+
+/*
+migrate_blocks: Migrate blocks from the context stage engine to the decoding stage engine
+
+This function is called by every decoding stage worker when the decoding
+stage engine decides to migrate some blocks from the context stage engine
+to the decoding stage engine.
+
+In the following code, "pp" stands for "pipeline parallel", and "tp" stands
+for "tensor parallel".
+
+Here we do not pass a cudaStream to the function. Instead we use the current
+stream indicated by at::cuda::getCurrentCUDAStream(). So it is python's
+responsibility to set the current stream before calling this function.
+*/
+
+void migrate_blocks(
+	// Parallelism parameters for the context stage engine
+	const int64_t context_pp_size,
+	const int64_t context_tp_size,
+
+	// Block indexes of the context stage engine
+	const std::vector<int64_t> &context_block_indexes,
+
+	// Parallelism parameters for the decoding stage engine
+	const int64_t decoding_pp_size,
+	const int64_t decoding_tp_size,
+
+	// Rank of the decoding stage worker that calls this function
+	const int64_t decoding_pp_rank,
+	const int64_t decoding_tp_rank,
+
+	// Block indexes of the decoding stage engine
+	const std::vector<int64_t> &decoding_block_indexes,
+
+	// The decoding stage worker's KV cache
+	torch::Tensor decoding_worker_k_cache,	// [num_blocks, layers_per_decoding_worker, heads_per_decoding_worker, block_size, head_dim]
+	torch::Tensor decoding_worker_v_cache
+) {
+	cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+	assert_whenever(decoding_worker_k_cache.is_contiguous());
+	assert_whenever(decoding_worker_v_cache.is_contiguous());
+
+	// Calculate some misc stuff
+	const int64_t layers_per_decoding_worker = decoding_worker_k_cache.size(1);
+	const int64_t heads_per_decoding_worker = decoding_worker_k_cache.size(2);
+	const int64_t block_size = decoding_worker_k_cache.size(3);
+	const int64_t head_dim = decoding_worker_k_cache.size(4);
+	const int64_t num_layers = layers_per_decoding_worker * decoding_pp_size;
+	const int64_t num_heads = heads_per_decoding_worker * decoding_tp_size;
+	const int64_t layers_per_context_worker = num_layers / context_pp_size;
+	const int64_t heads_per_context_worker = num_heads / context_tp_size;
+	const int64_t num_blocks_to_copy = decoding_block_indexes.size();
+	const int64_t dtype_size = decoding_worker_k_cache.dtype().itemsize();
+
+	// The current decoding worker's region of the k/v cache
+	const int64_t decoding_start_layer = decoding_pp_rank * layers_per_decoding_worker;
+	const int64_t decoding_end_layer = decoding_start_layer + layers_per_decoding_worker;
+	const int64_t decoding_start_head = decoding_tp_rank * heads_per_decoding_worker;
+	const int64_t decoding_end_head = decoding_start_head + heads_per_decoding_worker;
+
+	for (int64_t context_pp_rank = 0; context_pp_rank < context_pp_size; ++context_pp_rank) {
+		// First we iterate over every context pp stage
+		const int64_t context_start_layer = context_pp_rank * layers_per_context_worker;
+		const int64_t context_end_layer = context_start_layer + layers_per_context_worker;
+		if (context_end_layer <= decoding_start_layer || context_start_layer >= decoding_end_layer) {
+			continue;
+		}
+		for (int64_t context_tp_rank = 0; context_tp_rank < context_tp_size; ++context_tp_rank) {
+			// Then we iterate over every context tp worker in the current pp stage
+			const int64_t context_start_head = context_tp_rank * heads_per_context_worker;
+			const int64_t context_end_head = context_start_head + heads_per_context_worker;
+			if (context_end_head <= decoding_start_head || context_start_head >= decoding_end_head) {
+				continue;
+			}
+
+			// The current context worker's region intersects with the current decoding worker's region
+			// So we need to copy something from the context worker to the decoding worker
+			// The context worker holds k/v cache of range [context_start_layer, context_end_layer) x [context_start_head, context_end_head)
+			// The decoding worker holds k/v cache of range [decoding_start_layer, decoding_end_layer) x [decoding_start_head, decoding_end_head)
+			// We then calculate the intersection of these two ranges
+			const int64_t overlap_start_layer = std::max(context_start_layer, decoding_start_layer);
+			const int64_t overlap_end_layer = std::min(context_end_layer, decoding_end_layer);
+			const int64_t overlap_start_head = std::max(context_start_head, decoding_start_head);
+			const int64_t overlap_end_head = std::min(context_end_head, decoding_end_head);
+			assert_whenever(overlap_start_layer < overlap_end_layer);
+			assert_whenever(overlap_start_head < overlap_end_head);
+
+			// Note that this function is synchronous with respect to the host only if the source or destination of the transfer is host memory.
+			// Note also that this copy is serialized with respect to all pending and future asynchronous work in to the current device, the copy's source device, and the copy's destination device (use cudaMemcpy3DPeerAsync to avoid this synchronization).
+
+			// kv cache shape: [num_blocks, layers_per_worker, heads_per_worker, block_size, head_dim]
+			for (int64_t block_id = 0; block_id < num_blocks_to_copy; ++block_id) {
+				const int64_t context_block_index = context_block_indexes[block_id];
+				const int64_t decoding_block_index = decoding_block_indexes[block_id];
+				for (int is_value = 0; is_value < 2; ++is_value) {
+					const int64_t context_worker_hash = (context_pp_rank<<6) + context_tp_rank;
+					char* context_worker_base_ptr = (char*) (is_value ? context_worker_v_cache_addr[context_worker_hash] : context_worker_k_cache_addr[context_worker_hash]);
+					if (!context_worker_base_ptr) {
+						// This context worker has not registered. Panic
+						fprintf(stderr, "Error: context worker %ld-%ld has not registered\n", context_pp_rank, context_tp_rank);
+						exit(1);
+					}
+					CUDA_CHECK(cudaMemcpy2DAsync(
+						(char*) (is_value ? decoding_worker_v_cache.data_ptr() : decoding_worker_k_cache.data_ptr())
+							+ INDEX_5D(0, layers_per_decoding_worker, heads_per_decoding_worker, block_size, head_dim,
+								decoding_block_index,
+								overlap_start_layer - decoding_start_layer,
+								overlap_start_head - decoding_start_head,
+								0, 0) * dtype_size,
+						(uint64_t) ((block_size * head_dim * dtype_size) * heads_per_decoding_worker),
+						context_worker_base_ptr
+							+ INDEX_5D(0, layers_per_context_worker, heads_per_context_worker, block_size, head_dim,
+								context_block_index,
+								overlap_start_layer - context_start_layer,
+								overlap_start_head - context_start_head,
+								0, 0) * dtype_size,
+						(uint64_t) ((block_size * head_dim * dtype_size) * heads_per_context_worker),
+						(size_t) ((overlap_end_head - overlap_start_head) * block_size * head_dim * dtype_size),
+						(size_t) (overlap_end_layer - overlap_start_layer),
+						cudaMemcpyDeviceToDevice,
+						stream
+					));
+				}
+			}
+		}
+	}
 }

--- a/csrc/cache_kernels.cu
+++ b/csrc/cache_kernels.cu
@@ -420,6 +420,21 @@ extern void __assert_fail (const char *__assertion, const char *__file,
       : __assert_fail (#expr, __FILE__, __LINE__, __ASSERT_FUNCTION))
 }
 
+#define CUDA_CHECK(status)                                              \
+  {                                                                     \
+    cudaError_t error = status;                                         \
+    if (error != cudaSuccess) {                                         \
+      std::cerr << "Got bad cuda status: " << cudaGetErrorString(error) \
+                << " at line: " << __LINE__ << std::endl;               \
+      exit(EXIT_FAILURE);                                               \
+    }                                                                   \
+  }
+
+#define INDEX_5D(dim1, dim2, dim3, dim4, dim5, index1, index2, index3, index4, index5) \
+    (((int64_t)index1) * (dim2) * (dim3) * (dim4) * (dim5) + ((int64_t)index2) * (dim3) * (dim4) * (dim5) + ((int64_t)index3) * (dim4) * (dim5) + (index4) * (dim5) + (index5))
+
+
+
 
 static std::vector<int64_t> cudaIpcMemHandle2Bytes(const cudaIpcMemHandle_t &handle) {
 	std::vector<int64_t> result;

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -74,6 +74,20 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     "gather_cached_kv",
     &gather_cached_kv,
     "Gather key and value from the cache into contiguous QKV tensors");
+  cache_ops.def(
+    "get_ipc_mem_handle",
+    &get_ipc_mem_handle,
+    "Get IPC Memory handler for the KV caches");
+  cache_ops.def(
+    "register_ipc_mem_handle",
+    &register_ipc_mem_handle,
+    "Register memory handler for the KV caches");
+  cache_ops.def(
+    "migrate_blocks",
+    &migrate_blocks,
+    "Migrate KV cache blocks");
+
+
 
   // Cuda utils
   pybind11::module cuda_utils = m.def_submodule("cuda_utils", "vLLM cuda utils");

--- a/examples/offline_async_distserve.py
+++ b/examples/offline_async_distserve.py
@@ -32,7 +32,9 @@ async def main():
     final_output = []
     async for request_output in results_generator:
         final_output.append(request_output)
-        print(f"[User] At user level, received output for request: {request_output = }")
+        print(
+            f"[User] At user level, received output for request: {request_output = }"
+        )
 
     return final_output
 

--- a/examples/offline_async_distserve.py
+++ b/examples/offline_async_distserve.py
@@ -1,0 +1,41 @@
+import asyncio
+
+from vllm import AsyncLLMEngine, SamplingParams, LLM
+
+
+async def main():
+    engine_args = LLM(
+        model="facebook/opt-125m",
+        is_disaggregate=True,
+        # tensor_parallel_size=2,
+        tensor_parallel_size=1,
+        pipeline_parallel_size=2,
+        enforce_eager=True,
+        is_dummy_llm=True,
+    ).engine_args
+
+    engine = AsyncLLMEngine.from_engine_args(engine_args)
+    example_input = {
+        "prompt": "What is LLM?",
+        "stream": False,  # assume the non-streaming case
+        "temperature": 0.0,
+        "request_id": "0",
+    }
+
+    # start the generation
+    results_generator = engine.generate(
+        example_input["prompt"],
+        SamplingParams(temperature=example_input["temperature"]),
+        example_input["request_id"])
+
+    # get the results
+    final_output = []
+    async for request_output in results_generator:
+        final_output.append(request_output)
+        print(request_output)
+
+    return final_output
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/examples/offline_async_distserve.py
+++ b/examples/offline_async_distserve.py
@@ -32,7 +32,7 @@ async def main():
     final_output = []
     async for request_output in results_generator:
         final_output.append(request_output)
-        print(request_output)
+        print(f"[User] At user level, received output for request: {request_output = }")
 
     return final_output
 

--- a/examples/offline_async_distserve_2.py
+++ b/examples/offline_async_distserve_2.py
@@ -1,0 +1,63 @@
+import asyncio
+from typing import AsyncIterator
+
+from vllm import AsyncLLMEngine, SamplingParams, LLM, RequestOutput
+from vllm.engine.async_llm_engine import AsyncStream
+
+
+async def main():
+    engine_args = LLM(
+        model="facebook/opt-125m",
+        is_disaggregate=True,
+        # tensor_parallel_size=2,
+        tensor_parallel_size=1,
+        pipeline_parallel_size=2,
+        enforce_eager=True,
+        is_dummy_llm=True,
+    ).engine_args
+
+    engine = AsyncLLMEngine.from_engine_args(engine_args)
+    prompts = [
+        "Hello, my name is",
+        "The president of the United States is",
+        "The capital of France is",
+        "The future of AI is",
+    ]
+    # Create a sampling params object.
+    sampling_params = SamplingParams(temperature=0.8, top_p=0.95)
+
+    # start the generation
+    result_generators = []
+    for request_id, prompt in enumerate(prompts):
+        # FIXME: HACK - we assume engine always returns async stream.
+        gen: AsyncStream = engine.generate(prompt, sampling_params, str(request_id))
+        result_generators.append(gen)
+
+    # Async get whatever is available from the `result_generators`
+    # and print the results: print(f"[User] At user level, received output for request: {request_output = }")
+    final_output = []
+    while result_generators:
+        # Run all generators concurrently and wait for the first one to complete
+        done, pending = await asyncio.wait(
+            [asyncio.create_task(gen.__anext__()) for gen in result_generators],
+            return_when=asyncio.FIRST_COMPLETED
+        )
+
+        for task in done:
+            try:
+                result = task.result()
+                # Process the result here
+                print(f"[User] At user level, received output for request: {result = }")
+            except StopAsyncIteration:
+                # This generator is exhausted, remove it
+                result_generators.remove(task.get_coro().cr_await)
+
+        # Cancel any pending tasks (those that didn't finish first)
+        for task in pending:
+            task.cancel()
+
+    return final_output
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/examples/offline_async_distserve_2.py
+++ b/examples/offline_async_distserve_2.py
@@ -34,7 +34,6 @@ async def main():
                                            str(request_id))
         result_generators.append(gen)
 
-
     # Async get whatever is available from the `result_generators`
     # and print the results: print(f"[User] At user level, received output for request: {request_output = }")
     final_output = []

--- a/examples/offline_async_distserve_2.py
+++ b/examples/offline_async_distserve_2.py
@@ -34,6 +34,7 @@ async def main():
                                            str(request_id))
         result_generators.append(gen)
 
+
     # Async get whatever is available from the `result_generators`
     # and print the results: print(f"[User] At user level, received output for request: {request_output = }")
     final_output = []

--- a/examples/offline_inference.py
+++ b/examples/offline_inference.py
@@ -11,7 +11,7 @@ prompts = [
 sampling_params = SamplingParams(temperature=0.8, top_p=0.95)
 
 # Create an LLM.
-llm = LLM(model="facebook/opt-125m")
+llm = LLM(model="facebook/opt-125m", enforce_eager=True,)
 # Generate texts from the prompts. The output is a list of RequestOutput objects
 # that contain the prompt, generated text, and other information.
 outputs = llm.generate(prompts, sampling_params)

--- a/examples/offline_inference.py
+++ b/examples/offline_inference.py
@@ -11,7 +11,10 @@ prompts = [
 sampling_params = SamplingParams(temperature=0.8, top_p=0.95)
 
 # Create an LLM.
-llm = LLM(model="facebook/opt-125m", enforce_eager=True,)
+llm = LLM(
+    model="facebook/opt-125m",
+    enforce_eager=True,
+)
 # Generate texts from the prompts. The output is a list of RequestOutput objects
 # that contain the prompt, generated text, and other information.
 outputs = llm.generate(prompts, sampling_params)

--- a/examples/offline_inference_distserve.py
+++ b/examples/offline_inference_distserve.py
@@ -14,8 +14,10 @@ sampling_params = SamplingParams(temperature=0.8, top_p=0.95)
 llm = LLM(
     model="facebook/opt-125m",
     is_disaggregate=True,
-    tensor_parallel_size=2,
+    # tensor_parallel_size=2,
+    tensor_parallel_size=1,
     pipeline_parallel_size=2,
+    enforce_eager=False,  # disable model capture
 )
 # Generate texts from the prompts. The output is a list of RequestOutput objects
 # that contain the prompt, generated text, and other information.

--- a/examples/offline_inference_distserve.py
+++ b/examples/offline_inference_distserve.py
@@ -1,0 +1,27 @@
+from vllm import LLM, SamplingParams
+
+# Sample prompts.
+prompts = [
+    "Hello, my name is",
+    "The president of the United States is",
+    "The capital of France is",
+    "The future of AI is",
+]
+# Create a sampling params object.
+sampling_params = SamplingParams(temperature=0.8, top_p=0.95)
+
+# Create an LLM.
+llm = LLM(
+    model="facebook/opt-125m",
+    is_disaggregate=True,
+    tensor_parallel_size=2,
+    pipeline_parallel_size=2,
+)
+# Generate texts from the prompts. The output is a list of RequestOutput objects
+# that contain the prompt, generated text, and other information.
+outputs = llm.generate(prompts, sampling_params)
+# Print the outputs.
+for output in outputs:
+    prompt = output.prompt
+    generated_text = output.outputs[0].text
+    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")

--- a/examples/offline_inference_distserve.py
+++ b/examples/offline_inference_distserve.py
@@ -17,7 +17,7 @@ llm = LLM(
     # tensor_parallel_size=2,
     tensor_parallel_size=1,
     pipeline_parallel_size=2,
-    enforce_eager=False,  # disable model capture
+    enforce_eager=True,
 )
 # Generate texts from the prompts. The output is a list of RequestOutput objects
 # that contain the prompt, generated text, and other information.

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -261,6 +261,9 @@ class ModelConfig:
 
     def get_num_layers(self, parallel_config: "ParallelConfig") -> int:
         total_num_hidden_layers = self.hf_config.num_hidden_layers
+        # FIXME: (Hack) Support prefill disaggregation
+        if parallel_config.is_disaggregate:
+            return total_num_hidden_layers
         return total_num_hidden_layers // parallel_config.pipeline_parallel_size
 
 

--- a/vllm/core/dist_scheduler.py
+++ b/vllm/core/dist_scheduler.py
@@ -5,13 +5,16 @@ from vllm.config import SchedulerConfig, CacheConfig
 from vllm.core.scheduler import Scheduler, SchedulerOutputs
 from vllm.sequence import SequenceGroup, Sequence, SequenceGroupMetadata, SequenceStatus
 
+get_empty_output = lambda: SchedulerOutputs([], None, 0, {}, {}, {}, [])
+
 
 @dataclasses.dataclass
 class DistScheduleOutput:
+
     prefill_schedule: Tuple[List[SequenceGroupMetadata],
-                            SchedulerOutputs] = ([], None)
+                            SchedulerOutputs] = ([], get_empty_output())
     decode_schedule: Tuple[List[SequenceGroupMetadata],
-                           SchedulerOutputs] = ([], None)
+                           SchedulerOutputs] = ([], get_empty_output())
     # FIXME: Is the type actually correct? also need to
     #  assume send / recv blocks are one-to-one mapping
     send_blocks: List[int] = None

--- a/vllm/core/dist_scheduler.py
+++ b/vllm/core/dist_scheduler.py
@@ -16,7 +16,22 @@ class DistScheduleOutput:
     #  assume send / recv blocks are one-to-one mapping
     send_blocks: List[int] = None
     recv_blocks: List[int] = None
-    pass
+
+    @property
+    def prefill_metadata(self) -> List[SequenceGroupMetadata]:
+        return self.prefill_schedule[0]
+
+    @property
+    def prefill_output(self) -> SchedulerOutputs:
+        return self.prefill_schedule[1]
+
+    @property
+    def decode_metadata(self) -> List[SequenceGroupMetadata]:
+        return self.decode_schedule[0]
+
+    @property
+    def decode_output(self) -> SchedulerOutputs:
+        return self.decode_schedule[1]
 
 
 class DistScheduler:

--- a/vllm/core/dist_scheduler.py
+++ b/vllm/core/dist_scheduler.py
@@ -113,16 +113,17 @@ class DistScheduler:
     # TODO: The return type is super complex now...
     def _schedule_decode(
         self,
-        transfer_new_blocks: bool = False
+        should_transfer_new_blocks: bool = False
     ) -> Tuple[List[SequenceGroupMetadata], SchedulerOutputs, List[int],
                List[int]]:
-        # TODO: (Rename) transfer_new_blocks --> should_transfer_new_blocks
         assert not self.is_decode_in_progress, "Decoding is already ongoing."
+
+        # For decode scheduler, there are 2 modes for scheduling:
+        # 1. Transfer new blocks from prefill to decode.
+        #       This should hijack the scheduling logic for decode.
+        # 2. Decode without transferring new blocks.
         _result = self.decode_scheduler.schedule(
-            # TODO: In the Scheduler, implement this primitive.
-            enable_prefill=transfer_new_blocks,
-            enable_decode=not transfer_new_blocks,
-        )
+            only_transfer_new_blocks_in_decode=should_transfer_new_blocks, )
         metadata: List[SequenceGroupMetadata] = _result[0]
         output: SchedulerOutputs = _result[1]
         if metadata:
@@ -130,7 +131,7 @@ class DistScheduler:
         send_blocks = []
         recv_blocks = []
 
-        if transfer_new_blocks:
+        if should_transfer_new_blocks:
             for item in metadata:
                 # FIXME: The SequenceGroupMetadata should have tracked what metadata the prefill engine is using.
                 prefill_blocks = self.prefill_request_blocks[item.request_id]
@@ -160,7 +161,12 @@ class DistScheduler:
         # Update the blocks used in these prefill requests.
         for metadata in self.ongoing_prefill_requests_meta:
             # FIXME: Retrieve the blocks from the prefill workers.
-            self.prefill_request_blocks[metadata.request_id] = metadata.blocks
+            block_tables = metadata.block_tables
+            assert len(
+                block_tables
+            ) == 1, "Only one sequence should appear in prefill (hence one block table)."
+            blocks = list(block_tables.values())[0]
+            self.prefill_request_blocks[metadata.request_id] = blocks
 
         # Clear the stateful states for prefill
         self.ongoing_prefill_requests = []
@@ -182,6 +188,7 @@ class DistScheduler:
         return len(self.decode_scheduler.waiting) > 0
 
     def schedule(self) -> DistScheduleOutput:
+        # TODO: When to do the block migration?
         # Case 1: Prefill and decode are both occupied. Do nothing.
         if self.is_prefill_in_progress and self.is_decode_in_progress:
             return DistScheduleOutput()
@@ -199,7 +206,8 @@ class DistScheduler:
 
         # Case 3: Decode is free, but prefill is in progress.
         if self.is_prefill_in_progress and not self.is_decode_in_progress:
-            _decode_schedule = self._schedule_decode(transfer_new_blocks=False)
+            _decode_schedule = self._schedule_decode(
+                should_transfer_new_blocks=False)
             (metadata, output, send_blocks, recv_blocks) = _decode_schedule
 
             return DistScheduleOutput(
@@ -211,7 +219,7 @@ class DistScheduler:
         # Case 4: Nothing is happening. Schedule both prefill and decode.
         prefill_metadata, prefill_output = self._schedule_prefill()
         (decode_metadata, decode_output, send_blocks,
-         recv_blocks) = self._schedule_decode(transfer_new_blocks=False)
+         recv_blocks) = self._schedule_decode(should_transfer_new_blocks=False)
         return DistScheduleOutput(
             prefill_schedule=(prefill_metadata, prefill_output),
             decode_schedule=(decode_metadata, decode_output),

--- a/vllm/core/dist_scheduler.py
+++ b/vllm/core/dist_scheduler.py
@@ -167,10 +167,6 @@ class DistScheduler:
         # Once prefill worker pool finish up a KV cache transfer,
         # remove the sequence from the prefill scheduler.
         if is_transfer:
-            # Remove the requests from prefill.
-            self.prefill_scheduler.abort_seq_group(
-                self.pending_migration_requests)
-            self.pending_migration_requests = []
             return
 
         # Otherwise, it is a normal prefill step finishing.

--- a/vllm/core/dist_scheduler.py
+++ b/vllm/core/dist_scheduler.py
@@ -203,7 +203,7 @@ class DistScheduler:
 
     def has_pending_transfer(self):
         """Indicate there are requests waiting for KV Cache transfer."""
-        return len(self.decode_scheduler.waiting) > 0
+        return self.decode_scheduler.waiting or self.pending_migration_requests
 
     def schedule(self) -> DistScheduleOutput:
         # FIXME: Suboptimal scheduling algorithm if (actual) PP > 1.

--- a/vllm/core/dist_scheduler.py
+++ b/vllm/core/dist_scheduler.py
@@ -19,7 +19,7 @@ class DistScheduleOutput:
 
     @property
     def is_transfer_schedule(self):
-        return self.send_blocks and self.recv_blocks
+        return self.send_blocks is not None and self.recv_blocks is not None
 
     @property
     def has_prefill_schedule(self):

--- a/vllm/core/dist_scheduler.py
+++ b/vllm/core/dist_scheduler.py
@@ -1,0 +1,228 @@
+import dataclasses
+from typing import Union, Iterable, List, Tuple
+
+from vllm.config import SchedulerConfig, CacheConfig
+from vllm.core.scheduler import Scheduler, SchedulerOutputs
+from vllm.sequence import SequenceGroup, Sequence, SequenceGroupMetadata
+
+
+@dataclasses.dataclass
+class DistScheduleOutput:
+    prefill_schedule: Tuple[List[SequenceGroupMetadata],
+                            SchedulerOutputs] = None
+    decode_schedule: Tuple[List[SequenceGroupMetadata],
+                           SchedulerOutputs] = None
+    # FIXME: Is the type actually correct? also need to
+    #  assume send / recv blocks are one-to-one mapping
+    send_blocks: List[int] = None
+    recv_blocks: List[int] = None
+    pass
+
+
+class DistScheduler:
+
+    def __init__(
+        self,
+        scheduler_config: SchedulerConfig,
+        cache_config: CacheConfig,
+    ) -> None:
+        self.prefill_scheduler = Scheduler(scheduler_config, cache_config)
+        self.decode_scheduler = Scheduler(scheduler_config, cache_config)
+
+        # Set to True if prefill / decode is in progress
+        # TODO: (Rename) prefilling / decoding to is_prefilling / is_decoding
+        self.prefilling = False
+        self.decoding = False
+
+        self.ongoing_prefill_requests: 'Iterable[SequenceGroup]' = []
+        self.ongoing_prefill_requests_meta: 'List[SequenceGroupMetadata]' = []
+
+        # Tracking the KV cache in the prefill workers.
+        # Maps a sequence id to a list of physical block ids.
+        # i.e.: Sequence.seq_id -> [BlockID(int)]
+        self.prefill_request_blocks: 'Dict[int, List[int]]' = {}
+
+        # Requests scheduled for migration.
+        # TODO: (Rename) migration requests
+        self.pending_migration_requests = []
+
+        pass
+
+    def add_seq_group(self, seq_group: SequenceGroup) -> None:
+        # Add sequence groups to the waiting queue.
+        self.prefill_scheduler.add_seq_group(seq_group)
+        return
+
+    def abort_seq_group(self, request_id: Union[str, Iterable[str]]) -> None:
+        """Aborts a sequence group with the given ID.
+
+        Check if the sequence group with the given ID
+            is present in any of the state queue.
+        If present, remove the sequence group from the state queue.
+            Also, if any of the sequences in the sequence group is not finished,
+                free the sequence with status `FINISHED_ABORTED`.
+        Otherwise, do nothing.
+
+        Args:
+            request_id: The ID(s) of the sequence group to abort.
+        """
+        self.prefill_scheduler.abort_seq_group(request_id)
+        self.decode_scheduler.abort_seq_group(request_id)
+        return
+
+    def has_unfinished_seqs(self) -> bool:
+        return self.prefill_scheduler.has_unfinished_seqs(
+        ) or self.decode_scheduler.has_unfinished_seqs()
+
+    def get_num_unfinished_seq_groups(self) -> int:
+        a = self.prefill_scheduler.get_num_unfinished_seq_groups()
+        b = self.decode_scheduler.get_num_unfinished_seq_groups()
+        return a + b
+
+    def _schedule(self):
+        raise NotImplementedError
+
+    def _schedule_prefill(
+            self) -> Tuple[List[SequenceGroupMetadata], SchedulerOutputs]:
+        assert not self.prefilling, "Prefilling is already ongoing."
+
+        _result = self.prefill_scheduler.schedule()
+        metadata: List[SequenceGroupMetadata] = _result[0]
+        output: SchedulerOutputs = _result[1]
+        if metadata:
+            self.prefilling = True
+        self.ongoing_prefill_requests = output.scheduled_seq_groups
+        self.ongoing_prefill_requests_meta = metadata
+        return metadata, output
+
+    # TODO: The return type is super complex now...
+    def _schedule_decode(self, transfer_new_blocks: bool = False):
+        # TODO: (Rename) transfer_new_blocks --> should_transfer_new_blocks
+        assert not self.decoding, "Decoding is already ongoing."
+        _result = self.decode_scheduler.schedule(
+            # TODO: In the Scheduler, implement this primitive.
+            enable_prefill=transfer_new_blocks,
+            enable_decode=not transfer_new_blocks,
+        )
+        metadata: List[SequenceGroupMetadata] = _result[0]
+        output: SchedulerOutputs = _result[1]
+        if metadata:
+            self.decoding = True
+        send_blocks = []
+        recv_blocks = []
+
+        if transfer_new_blocks:
+            for item in metadata:
+                # FIXME: The SequenceGroupMetadata should have tracked what metadata the prefill engine is using.
+                prefill_blocks = self.prefill_request_blocks[item.request_id]
+                decode_blocks = item.block_tables
+
+                for seq_id, blocks in prefill_blocks.items():
+                    send_blocks.extend(blocks)
+                    recv_blocks.extend(decode_blocks[seq_id])
+                    pass
+
+            for item, seq_group in zip(metadata, output.scheduled_seq_groups):
+                is_seq_group_not_prefilled = item.is_prompt
+                self.decode_scheduler.add_seq_group(seq_group)
+            pass
+
+        return metadata, output, send_blocks, recv_blocks
+
+    def on_prefill_finish(self):
+        """Function passing into the prefill_scheduler."""
+        assert self.prefilling, "Prefilling is not ongoing."
+        self.prefilling = False
+
+        # Forward the requests to the decode scheduler.
+        # TODO: May need to pool these requests in a queue.
+        for seq_group in self.ongoing_prefill_requests:
+            self.decode_scheduler.add_seq_group(seq_group)
+        # Update the blocks used in these prefill requests.
+        for metadata in self.ongoing_prefill_requests_meta:
+            # FIXME: Retrieve the blocks from the prefill workers.
+            self.prefill_request_blocks[metadata.request_id] = metadata.blocks
+
+        # Clear the stateful states for prefill
+        self.ongoing_prefill_requests = []
+        self.ongoing_prefill_requests_meta = []
+        return
+
+    def on_decode_finish(self):
+        """Function passing into the decode_scheduler."""
+        assert self.decoding, "Decoding is not ongoing."
+        self.decoding = False
+
+        # TODO: Simply assuming the decode always drains the migration.
+        self.prefill_scheduler.abort_seq_group(self.pending_migration_requests)
+        self.pending_migration_requests = None
+        return
+
+    def has_pending_transfer(self):
+        """Indicate there are requests waiting for KV Cache transfer."""
+        return len(self.decode_scheduler.waiting) > 0
+
+    def schedule(self) -> DistScheduleOutput:
+        # Case 1: Prefill and decode are both occupied. Do nothing.
+        if self.prefilling and self.decoding:
+            return DistScheduleOutput()
+
+        # Case 2: Decode is occupied, but prefill is not.
+        if not self.prefilling and self.decoding:
+            # Case 2.1: There are requests being transferred from prefill to decode.
+            # Do nothing and wait for the transfer to finish.
+            if self.has_pending_transfer():
+                return DistScheduleOutput()
+
+            # Case 2.2: Prefill is actually free. Schedule once for prefill.
+            metadata, output = self._schedule_prefill()
+            return DistScheduleOutput(prefill_schedule=(metadata, output), )
+
+        # Case 3: Prefill is occupied, but decode is not.
+        if not self.prefilling and self.decoding:
+            _decode_schedule = self._schedule_decode(transfer_new_blocks=False)
+            (metadata, output, send_blocks, recv_blocks) = _decode_schedule
+
+            return DistScheduleOutput(
+                decode_schedule=(metadata, output),
+                send_blocks=send_blocks,
+                recv_blocks=recv_blocks,
+            )
+
+        # Case 4: Nothing is happening. Schedule both prefill and decode.
+        # if not self.prefilling and not self.decoding:
+        prefill_metadata, prefill_output = self._schedule_prefill()
+        (decode_metadata, decode_output, send_blocks,
+         recv_blocks) = self._schedule_decode(transfer_new_blocks=False)
+        return DistScheduleOutput(
+            prefill_schedule=(prefill_metadata, prefill_output),
+            decode_schedule=(decode_metadata, decode_output),
+            send_blocks=send_blocks,
+            recv_blocks=recv_blocks,
+        )
+
+    def fork_seq(self, parent_seq: Sequence, child_seq: Sequence) -> None:
+        # TODO: Assert the sequence is in decoding phase,
+        #  and fork the sequence using decode_scheduler.fork_seq()
+        #  This requires block transfer supporting block allocation
+        #  to be separate from the block transfer (so the block mapping
+        #  does not require the block in prefill to be the same ID as block in decode).
+        raise NotImplementedError
+
+    def free_seq(self, seq: Sequence):
+        self.prefill_scheduler.free_seq(seq)
+        self.decode_scheduler.free_seq(seq)
+        return
+
+    def free_finished_seq_groups(self) -> None:
+        self.prefill_scheduler.free_finished_seq_groups()
+        self.decode_scheduler.free_finished_seq_groups()
+        return
+
+    # _allocate
+    # _append_slot
+    # _preempt
+    # _preempt_by_recompute
+    # _preempt_by_swap
+    # _swap_in
+    # _swap_out

--- a/vllm/core/dist_scheduler.py
+++ b/vllm/core/dist_scheduler.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Union, Iterable, List, Tuple
+from typing import Union, Iterable, List, Tuple, Dict
 
 from vllm.config import SchedulerConfig, CacheConfig
 from vllm.core.scheduler import Scheduler, SchedulerOutputs

--- a/vllm/core/dist_scheduler.py
+++ b/vllm/core/dist_scheduler.py
@@ -168,7 +168,8 @@ class DistScheduler:
         # remove the sequence from the prefill scheduler.
         if is_transfer:
             # Remove the requests from prefill.
-            self.prefill_scheduler.abort_seq_group(self.pending_migration_requests)
+            self.prefill_scheduler.abort_seq_group(
+                self.pending_migration_requests)
             self.pending_migration_requests = None
             return
 

--- a/vllm/core/dist_scheduler.py
+++ b/vllm/core/dist_scheduler.py
@@ -1,4 +1,5 @@
 import dataclasses
+from copy import deepcopy
 from typing import Union, Iterable, List, Tuple, Dict
 
 from vllm.config import SchedulerConfig, CacheConfig
@@ -173,9 +174,9 @@ class DistScheduler:
         # Forward the requests to the decode scheduler.
         for seq_group in self._in_progress_prefill_requests:
             assert isinstance(seq_group, SequenceGroup)
-            # Rewind the state of the sequences within the sequence group
-            seq_group.hacky_rewind()
-            self.decode_scheduler.add_seq_group(seq_group)
+            new_seq_group = deepcopy(seq_group)
+            new_seq_group.hacky_rewind()
+            self.decode_scheduler.add_seq_group(new_seq_group)
             # TODO: Suppress the seq_group running prefill.
             #  We currently do this after on_decode_finish,
             #  which also removes the sequence from prefill scheduler.

--- a/vllm/core/dist_scheduler.py
+++ b/vllm/core/dist_scheduler.py
@@ -196,10 +196,12 @@ class DistScheduler:
             # Perform pending transfer.
             (decode_metadata, decode_output, send_blocks,
              recv_blocks) = self._schedule_decode(
-                 should_transfer_new_blocks=False)
+                 should_transfer_new_blocks=True)
             self.pending_migration_requests = [
                 g.request_id for g in decode_output.scheduled_seq_groups
             ]
+            self.is_prefill_in_progress = True
+            self.is_decode_in_progress = True
             return DistScheduleOutput(
                 # decode_schedule=(decode_metadata, decode_output),
                 send_blocks=send_blocks,

--- a/vllm/core/dist_scheduler.py
+++ b/vllm/core/dist_scheduler.py
@@ -210,6 +210,8 @@ class DistScheduler:
         # FIXME: Suboptimal scheduling algorithm if (actual) PP > 1.
 
         # Case 0: Transfer should be scheduled.
+        # FIXME: Suboptimal - relax the pending transfer condition such that
+        #  even if there are transfer request, we don't have to schedule it.
         if self.has_pending_transfer():
             if self.is_prefill_in_progress or self.is_decode_in_progress:
                 return DistScheduleOutput()

--- a/vllm/core/dist_scheduler.py
+++ b/vllm/core/dist_scheduler.py
@@ -202,7 +202,7 @@ class DistScheduler:
 
         # TODO: Simply assuming the decode always drains the migration.
         self.prefill_scheduler.abort_seq_group(self.pending_migration_requests)
-        self.pending_migration_requests = None
+        self.pending_migration_requests = []
         return
 
     def has_pending_transfer(self):

--- a/vllm/core/dist_scheduler.py
+++ b/vllm/core/dist_scheduler.py
@@ -174,7 +174,7 @@ class DistScheduler:
         for seq_group in self._in_progress_prefill_requests:
             assert isinstance(seq_group, SequenceGroup)
             # Rewind the state of the sequences within the sequence group
-            seq_group.hacky_rewind(SequenceStatus.WAITING)
+            seq_group.hacky_rewind()
             self.decode_scheduler.add_seq_group(seq_group)
             # TODO: Suppress the seq_group running prefill.
             #  We currently do this after on_decode_finish,

--- a/vllm/core/dist_scheduler.py
+++ b/vllm/core/dist_scheduler.py
@@ -9,9 +9,9 @@ from vllm.sequence import SequenceGroup, Sequence, SequenceGroupMetadata
 @dataclasses.dataclass
 class DistScheduleOutput:
     prefill_schedule: Tuple[List[SequenceGroupMetadata],
-                            SchedulerOutputs] = None
+                            SchedulerOutputs] = ([], None)
     decode_schedule: Tuple[List[SequenceGroupMetadata],
-                           SchedulerOutputs] = None
+                           SchedulerOutputs] = ([], None)
     # FIXME: Is the type actually correct? also need to
     #  assume send / recv blocks are one-to-one mapping
     send_blocks: List[int] = None

--- a/vllm/core/dist_scheduler.py
+++ b/vllm/core/dist_scheduler.py
@@ -170,13 +170,8 @@ class DistScheduler:
             self.decode_scheduler.add_seq_group(seq_group)
         # Update the blocks used in these prefill requests.
         for metadata in self._in_progress_prefill_requests_metadatas:
-            # FIXME: Retrieve the blocks from the prefill workers.
             block_tables = metadata.block_tables
-            assert len(
-                block_tables
-            ) == 1, "Only one sequence should appear in prefill (hence one block table)."
-            blocks = list(block_tables.values())[0]
-            self.prefill_memblocks[metadata.request_id] = blocks
+            self.prefill_memblocks[metadata.request_id] = block_tables
 
         # Clear the stateful states for prefill
         self._in_progress_prefill_requests = []

--- a/vllm/core/dist_scheduler.py
+++ b/vllm/core/dist_scheduler.py
@@ -266,7 +266,8 @@ class DistScheduler:
         #  This requires block transfer supporting block allocation
         #  to be separate from the block transfer (so the block mapping
         #  does not require the block in prefill to be the same ID as block in decode).
-        raise NotImplementedError
+        self.decode_scheduler.fork_seq(parent_seq, child_seq)
+        return
 
     def free_seq(self, seq: Sequence):
         self.prefill_scheduler.free_seq(seq)

--- a/vllm/core/dist_scheduler.py
+++ b/vllm/core/dist_scheduler.py
@@ -22,6 +22,14 @@ class DistScheduleOutput:
         return self.send_blocks and self.recv_blocks
 
     @property
+    def has_prefill_schedule(self):
+        return len(self.prefill_metadata) > 0
+
+    @property
+    def has_decode_schedule(self):
+        return len(self.decode_metadata) > 0
+
+    @property
     def prefill_metadata(self) -> List[SequenceGroupMetadata]:
         return self.prefill_schedule[0]
 

--- a/vllm/core/dist_scheduler.py
+++ b/vllm/core/dist_scheduler.py
@@ -170,7 +170,7 @@ class DistScheduler:
             # Remove the requests from prefill.
             self.prefill_scheduler.abort_seq_group(
                 self.pending_migration_requests)
-            self.pending_migration_requests = None
+            self.pending_migration_requests = []
             return
 
         # Otherwise, it is a normal prefill step finishing.

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -59,6 +59,8 @@ class SchedulerOutputs:
             f"blocks_to_copy={self.blocks_to_copy}, "
             f"ignored_seq_groups={self.ignored_seq_groups})")
 
+    __str__ = __repr__
+
     def is_empty(self) -> bool:
         # NOTE: We do not consider the ignored sequence groups.
         return (not self.scheduled_seq_groups and not self.blocks_to_swap_in

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -249,6 +249,8 @@ class Scheduler:
         preempted: List[SequenceGroup] = []
         while self.running:
             seq_group = self.running.popleft()
+
+            # Eviction if needed
             while not self.block_manager.can_append_slot(seq_group):
                 if self.running:
                     # Preempt the lowest-priority sequence groups.

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -173,8 +173,8 @@ class Scheduler:
                 waiting_seqs = seq_group.get_seqs(
                     status=SequenceStatus.WAITING)
                 assert len(waiting_seqs) == 1, (
-                    "Waiting sequence group should have only one prompt "
-                    "sequence.")
+                    f"Waiting sequence group should have only one prompt "
+                    f"sequence. Got { len(waiting_seqs) } sequences.")
                 num_prompt_tokens = waiting_seqs[0].get_len()
                 if num_prompt_tokens > self.prompt_limit:
                     logger.warning(

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -49,6 +49,16 @@ class SchedulerOutputs:
         assert not (blocks_to_swap_in and blocks_to_swap_out)
         self.ignored_seq_groups = ignored_seq_groups
 
+    def __repr__(self):
+        return (
+            f"SchedulerOutputs(scheduled_seq_groups={self.scheduled_seq_groups}, "
+            f"prompt_run={self.prompt_run}, "
+            f"num_batched_tokens={self.num_batched_tokens}, "
+            f"blocks_to_swap_in={self.blocks_to_swap_in}, "
+            f"blocks_to_swap_out={self.blocks_to_swap_out}, "
+            f"blocks_to_copy={self.blocks_to_copy}, "
+            f"ignored_seq_groups={self.ignored_seq_groups})")
+
     def is_empty(self) -> bool:
         # NOTE: We do not consider the ignored sequence groups.
         return (not self.scheduled_seq_groups and not self.blocks_to_swap_in

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -299,25 +299,7 @@ class Scheduler:
         return scheduler_outputs
 
     def schedule(
-        self,
-        only_transfer_new_blocks_in_decode: bool = False,
-    ) -> Tuple[List[SequenceGroupMetadata], SchedulerOutputs]:
-
-        if only_transfer_new_blocks_in_decode:
-            # Get the requests in the waiting queue.
-            scheduled_seq_groups = list(self.waiting)
-            seq_group_metadata_list: List[SequenceGroupMetadata] = []
-            scheduler_outputs = SchedulerOutputs(
-                scheduled_seq_groups=scheduled_seq_groups,
-                prompt_run=False,
-                num_batched_tokens=0,
-                blocks_to_swap_in={},
-                blocks_to_swap_out={},
-                blocks_to_copy={},
-                ignored_seq_groups=[],
-            )
-            return seq_group_metadata_list, scheduler_outputs
-
+        self, ) -> Tuple[List[SequenceGroupMetadata], SchedulerOutputs]:
         # Schedule sequence groups.
         # This function call changes the internal states of the scheduler
         # such as self.running, self.swapped, and self.waiting.

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -298,7 +298,26 @@ class Scheduler:
         )
         return scheduler_outputs
 
-    def schedule(self) -> Tuple[List[SequenceGroupMetadata], SchedulerOutputs]:
+    def schedule(
+        self,
+        only_transfer_new_blocks_in_decode: bool = False,
+    ) -> Tuple[List[SequenceGroupMetadata], SchedulerOutputs]:
+
+        if only_transfer_new_blocks_in_decode:
+            # Get the requests in the waiting queue.
+            scheduled_seq_groups = list(self.waiting)
+            seq_group_metadata_list: List[SequenceGroupMetadata] = []
+            scheduler_outputs = SchedulerOutputs(
+                scheduled_seq_groups=scheduled_seq_groups,
+                prompt_run=False,
+                num_batched_tokens=0,
+                blocks_to_swap_in={},
+                blocks_to_swap_out={},
+                blocks_to_copy={},
+                ignored_seq_groups=[],
+            )
+            return seq_group_metadata_list, scheduler_outputs
+
         # Schedule sequence groups.
         # This function call changes the internal states of the scheduler
         # such as self.running, self.swapped, and self.waiting.

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -216,12 +216,13 @@ class EngineArgs:
     def create_engine_configs(
         self,
     ) -> Tuple[ModelConfig, CacheConfig, ParallelConfig, SchedulerConfig]:
-        model_config = ModelConfig(
-            self.model, self.tokenizer, self.tokenizer_mode,
-            self.trust_remote_code, self.download_dir, self.load_format,
-            self.dtype, self.seed, self.revision, self.tokenizer_revision,
-            self.max_model_len, self.quantization, self.enforce_eager,
-            self.max_context_len_to_capture)
+        model_config = ModelConfig(self.model, self.tokenizer,
+                                   self.tokenizer_mode, self.trust_remote_code,
+                                   self.download_dir, self.load_format,
+                                   self.dtype, self.seed, self.revision,
+                                   self.tokenizer_revision, self.max_model_len,
+                                   self.quantization, self.enforce_eager,
+                                   self.max_context_len_to_capture)
         cache_config = CacheConfig(self.block_size,
                                    self.gpu_memory_utilization,
                                    self.swap_space,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -37,6 +37,11 @@ class EngineArgs:
     max_context_len_to_capture: int = 8192
     is_disaggregate: bool = False
 
+    # FIXME: (Hack) bypass the engine args validation for the dummy LLM.
+    engine_use_ray: bool = False
+    disable_log_requests: bool = False
+    max_log_len: Optional[int] = None
+
     def __post_init__(self):
         if self.tokenizer is None:
             self.tokenizer = self.model

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -35,6 +35,7 @@ class EngineArgs:
     quantization: Optional[str] = None
     enforce_eager: bool = False
     max_context_len_to_capture: int = 8192
+    is_disaggregate: bool = False
 
     def __post_init__(self):
         if self.tokenizer is None:
@@ -215,13 +216,12 @@ class EngineArgs:
     def create_engine_configs(
         self,
     ) -> Tuple[ModelConfig, CacheConfig, ParallelConfig, SchedulerConfig]:
-        model_config = ModelConfig(self.model, self.tokenizer,
-                                   self.tokenizer_mode, self.trust_remote_code,
-                                   self.download_dir, self.load_format,
-                                   self.dtype, self.seed, self.revision,
-                                   self.tokenizer_revision, self.max_model_len,
-                                   self.quantization, self.enforce_eager,
-                                   self.max_context_len_to_capture)
+        model_config = ModelConfig(
+            self.model, self.tokenizer, self.tokenizer_mode,
+            self.trust_remote_code, self.download_dir, self.load_format,
+            self.dtype, self.seed, self.revision, self.tokenizer_revision,
+            self.max_model_len, self.quantization, self.enforce_eager,
+            self.max_context_len_to_capture, self.is_disaggregate)
         cache_config = CacheConfig(self.block_size,
                                    self.gpu_memory_utilization,
                                    self.swap_space,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -221,7 +221,7 @@ class EngineArgs:
             self.trust_remote_code, self.download_dir, self.load_format,
             self.dtype, self.seed, self.revision, self.tokenizer_revision,
             self.max_model_len, self.quantization, self.enforce_eager,
-            self.max_context_len_to_capture, self.is_disaggregate)
+            self.max_context_len_to_capture)
         cache_config = CacheConfig(self.block_size,
                                    self.gpu_memory_utilization,
                                    self.swap_space,
@@ -229,7 +229,8 @@ class EngineArgs:
         parallel_config = ParallelConfig(self.pipeline_parallel_size,
                                          self.tensor_parallel_size,
                                          self.worker_use_ray,
-                                         self.max_parallel_loading_workers)
+                                         self.max_parallel_loading_workers,
+                                         self.is_disaggregate)
         scheduler_config = SchedulerConfig(self.max_num_batched_tokens,
                                            self.max_num_seqs,
                                            model_config.max_model_len,

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -228,7 +228,8 @@ class _AsyncLLMEngine(LLMEngine):
                 "blocks_to_swap_in": scheduler_outputs.blocks_to_swap_in,
                 "blocks_to_swap_out": scheduler_outputs.blocks_to_swap_out,
                 "blocks_to_copy": scheduler_outputs.blocks_to_copy,
-                # FIXME: Add transfer block event.
+                "send_blocks": dist_output.send_blocks,
+                "recv_blocks": dist_output.recv_blocks,
             }
             all_outputs = await self._run_dist_worker_group_async(
                 worker_group,

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -222,7 +222,8 @@ class _AsyncLLMEngine(LLMEngine):
 
         # Invoke execute model
         output = []
-        if not scheduler_outputs.is_empty():
+        if not scheduler_outputs.is_empty(
+        ) or dist_output.is_transfer_schedule:
             data = {
                 "seq_group_metadata_list": seq_group_metadata_list,
                 "blocks_to_swap_in": scheduler_outputs.blocks_to_swap_in,

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -565,11 +565,13 @@ class AsyncLLMEngine:
         else:
             self.engine.abort_request(request_ids)
 
-    async def run_engine_loop(self):
+    async def run_engine_loop(self, return_at_finish=False):
         # Initialize the RequestTracker here so it uses the right event loop.
         has_requests_in_progress = False
         while True:
             if not has_requests_in_progress:
+                if return_at_finish:
+                    return
                 # Wait for new requests if there are no requests in progress.
                 debug_pront("Waiting for new requests...")
                 await self._request_tracker.wait_for_new_requests()

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -322,7 +322,7 @@ class _AsyncLLMEngine(LLMEngine):
         result = []
         for future in finished:
             output, is_prefill, is_transfer = await future
-            logger.info(f"Accepted a finished task {is_prefill = }.")
+            logger.info(f"Accepted a finished task {is_prefill = }, {is_transfer = }.")
             if is_prefill:
                 scheduler.on_prefill_finish(is_transfer=is_transfer)
             else:
@@ -333,7 +333,7 @@ class _AsyncLLMEngine(LLMEngine):
         logger.info(f"Obtain result: {result = }.")
 
         logger.info(
-            f"Scheduler properties: "
+            f"Scheduler properties: \n"
             f"{scheduler.is_prefill_in_progress = }, \n"
             f"{scheduler.is_decode_in_progress = }, \n"
             f"{scheduler._in_progress_prefill_requests = }, \n"

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -239,11 +239,18 @@ class _AsyncLLMEngine(LLMEngine):
                 f"{'Prefill pool' if is_prefill else 'Decode pool'} invoking execute_model with data: {data}"
             )
 
+            exec_start_time = time.perf_counter()
             all_outputs = await self._run_dist_worker_group_async(
                 worker_group,
                 "execute_model",
                 **data,
             )
+            exec_end_time = time.perf_counter()
+            duration = exec_end_time - exec_start_time
+            duration *= 1000
+            logger.info(
+                f"_invoke_dist_workers[{step = }] spent {duration:.2f} s.")
+
             output = all_outputs[0]
 
         step_output = self._process_model_outputs(output, scheduler_outputs)

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -333,10 +333,11 @@ class _AsyncLLMEngine(LLMEngine):
         for future in finished:
             output, is_prefill, is_transfer, (start_time, step) = await future
             duration = time.time() - start_time
+            duration *= 1000
             task_name = 'prefill' if is_prefill else 'decode'
             if is_transfer:
                 task_name += '_transfer'
-            debug_pront_3(f"Accepted a finished task {step = } {task_name = } (step finished in {duration = })")
+            debug_pront_3(f"Accepted a finished task {step = } {task_name = } (step finished in {duration:.2f} ms).")
             if is_prefill:
                 scheduler.on_prefill_finish(is_transfer=is_transfer)
             else:

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -322,7 +322,8 @@ class _AsyncLLMEngine(LLMEngine):
         result = []
         for future in finished:
             output, is_prefill, is_transfer = await future
-            logger.info(f"Accepted a finished task {is_prefill = }, {is_transfer = }.")
+            logger.info(
+                f"Accepted a finished task {is_prefill = }, {is_transfer = }.")
             if is_prefill:
                 scheduler.on_prefill_finish(is_transfer=is_transfer)
             else:

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -249,8 +249,12 @@ class _AsyncLLMEngine(LLMEngine):
         return step_output, is_prefill, is_transfer
 
     async def step_dist_async(self) -> Tuple[List[RequestOutput], bool]:
-        # FIXME: Hack - decouple the concept of "running" vs "has output"
+        """
+        Step once in distserve mode.
 
+        Returns: (step_output: List[RequestOutput], is_running: bool)
+
+        """
         self.iteration_counter += 1
         debug_pront("\n-------------------\n")
         debug_pront(

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -80,7 +80,7 @@ class RequestTracker:
         self._request_streams: Dict[str, AsyncStream] = {}
         self._finished_requests: asyncio.Queue[str] = asyncio.Queue()
         self._new_requests: asyncio.Queue[Tuple[AsyncStream,
-        dict]] = asyncio.Queue()
+                                                dict]] = asyncio.Queue()
         self.new_requests_event = None
 
     def __contains__(self, item):
@@ -139,7 +139,7 @@ class RequestTracker:
         self._finished_requests.put_nowait(request_id)
 
         if request_id not in self._request_streams or self._request_streams[
-            request_id].finished:
+                request_id].finished:
             # The request has already finished or been aborted.
             return
 
@@ -630,7 +630,7 @@ class AsyncLLMEngine:
                     shortened_prompt = shortened_prompt[:self.max_log_len]
                 if shortened_token_ids is not None:
                     shortened_token_ids = shortened_token_ids[:self.
-                    max_log_len]
+                                                              max_log_len]
             # logger.info(f"Received request {request_id}: "
             #             f"prompt: {shortened_prompt!r}, "
             #             f"prefix_pos: {prefix_pos},"

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -251,9 +251,6 @@ class _AsyncLLMEngine(LLMEngine):
     async def step_dist_async(self) -> Tuple[List[RequestOutput], bool]:
         # FIXME: Hack - decouple the concept of "running" vs "has output"
 
-        # Sleep 1 second
-        await asyncio.sleep(1)
-
         self.iteration_counter += 1
         logger.info("\n-------------------\n")
         logger.info(

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -232,6 +232,7 @@ class _AsyncLLMEngine(LLMEngine):
                 "send_blocks": dist_output.send_blocks,
                 "recv_blocks": dist_output.recv_blocks,
             }
+            logger.info(f"{'Prefill pool' if is_prefill else 'Decode pool' } invoking execute_model with {data = }.")
             all_outputs = await self._run_dist_worker_group_async(
                 worker_group,
                 "execute_model",
@@ -253,11 +254,22 @@ class _AsyncLLMEngine(LLMEngine):
         assert isinstance(scheduler, DistScheduler)
 
         scheduler_outputs: DistScheduleOutput = scheduler.schedule()
-        logger.info(f"Create one scheduler outputs: {scheduler_outputs}.")
-        logger.info(f"Scheduler outputs properties: "
-                    f"{scheduler_outputs.is_transfer_schedule = }, "
-                    f"{len(scheduler_outputs.prefill_metadata) = },"
-                    f"{len(scheduler_outputs.decode_metadata) = }.")
+        logger.info(f"Scheduler outputs properties: \n"
+                    f"{scheduler_outputs.is_transfer_schedule = },\n"
+                    f"{scheduler_outputs.has_prefill_schedule = },\n"
+                    f"{scheduler_outputs.has_decode_schedule = },\n"
+                    )
+        logger.info(f"Prefill scheduler: \n"
+                    f"{len(scheduler.prefill_scheduler.waiting) } \n"
+                    f"{len(scheduler.prefill_scheduler.running) } \n"
+                    f"{len(scheduler.prefill_scheduler.swapped) } \n"
+                    )
+        logger.info(f"Decode scheduler: \n"
+                    f"{len(scheduler.decode_scheduler.waiting) } \n"
+                    f"{len(scheduler.decode_scheduler.running) } \n"
+                    f"{len(scheduler.decode_scheduler.swapped) } \n"
+                    )
+
         prefill_future = None
         decode_future = None
 

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -323,8 +323,11 @@ class _AsyncLLMEngine(LLMEngine):
         result = []
         for future in finished:
             output, is_prefill, is_transfer = await future
-            debug_pront_2(
-                f"Accepted a finished task {is_prefill = }, {is_transfer = }.")
+            task_name = 'prefill' if is_prefill else 'decode'
+            if is_transfer:
+                task_name += '_transfer'
+            debug_pront_3(
+                f"Accepted a finished task {task_name = }.")
             if is_prefill:
                 scheduler.on_prefill_finish(is_transfer=is_transfer)
             else:

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -12,7 +12,7 @@ from vllm.engine.ray_utils import initialize_cluster, ray
 from vllm.logger import init_logger
 from vllm.outputs import RequestOutput
 from vllm.sampling_params import SamplingParams
-from vllm.utils import debug_pront, debug_pront_2
+from vllm.utils import debug_pront, debug_pront_2, debug_pront_3
 
 logger = init_logger(__name__)
 
@@ -257,7 +257,7 @@ class _AsyncLLMEngine(LLMEngine):
         """
         self.iteration_counter += 1
         debug_pront_2("\n-------------------\n")
-        debug_pront_2(
+        debug_pront_3(
             f"Starting step_dist_async() step {self.iteration_counter}.")
         assert self.parallel_config.is_disaggregate
 
@@ -285,7 +285,7 @@ class _AsyncLLMEngine(LLMEngine):
         if scheduler_outputs.is_transfer_schedule:
             assert scheduler.is_prefill_in_progress and scheduler.is_decode_in_progress, \
                 "Block migration must schedule both prefill and decode."
-            debug_pront_2(f"Block migration is invoked.")
+            debug_pront_3(f"Block migration is invoked.")
             prefill_future = self._invoke_dist_workers(scheduler_outputs,
                                                        is_prefill=True)
             decode_future = self._invoke_dist_workers(scheduler_outputs,
@@ -296,13 +296,13 @@ class _AsyncLLMEngine(LLMEngine):
             if scheduler_outputs.has_prefill_schedule:
                 assert scheduler.is_prefill_in_progress, \
                     "Prefill schedule must be invoked when prefill is in progress."
-                debug_pront_2(f"Prefill schedule is invoked.")
+                debug_pront_3(f"Prefill schedule is invoked.")
                 prefill_future = self._invoke_dist_workers(scheduler_outputs,
                                                            is_prefill=True)
             if scheduler_outputs.has_decode_schedule:
                 assert scheduler.is_decode_in_progress, \
                     "Decode schedule must be invoked when decode is in progress."
-                debug_pront_2(f"Decode schedule is invoked.")
+                debug_pront_3(f"Decode schedule is invoked.")
                 decode_future = self._invoke_dist_workers(scheduler_outputs,
                                                           is_prefill=False)
 

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -336,7 +336,7 @@ class _AsyncLLMEngine(LLMEngine):
             task_name = 'prefill' if is_prefill else 'decode'
             if is_transfer:
                 task_name += '_transfer'
-            debug_pront_3(f"Accepted a finished task {step = } {task_name = } (step finished in {duration = } ). })")
+            debug_pront_3(f"Accepted a finished task {step = } {task_name = } (step finished in {duration = })")
             if is_prefill:
                 scheduler.on_prefill_finish(is_transfer=is_transfer)
             else:

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -249,7 +249,7 @@ class _AsyncLLMEngine(LLMEngine):
             duration = exec_end_time - exec_start_time
             duration *= 1000
             logger.info(
-                f"_invoke_dist_workers[{step = }] spent {duration:.2f} s.")
+                f"_invoke_dist_workers[{step = }] spent {duration:.2f} ms.")
 
             output = all_outputs[0]
 

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -260,14 +260,14 @@ class _AsyncLLMEngine(LLMEngine):
                     f"{scheduler_outputs.has_decode_schedule = },\n"
                     )
         logger.info(f"Prefill scheduler: \n"
-                    f"{len(scheduler.prefill_scheduler.waiting) } \n"
-                    f"{len(scheduler.prefill_scheduler.running) } \n"
-                    f"{len(scheduler.prefill_scheduler.swapped) } \n"
+                    f"{len(scheduler.prefill_scheduler.waiting) = } \n"
+                    f"{len(scheduler.prefill_scheduler.running) = } \n"
+                    f"{len(scheduler.prefill_scheduler.swapped) = } \n"
                     )
         logger.info(f"Decode scheduler: \n"
-                    f"{len(scheduler.decode_scheduler.waiting) } \n"
-                    f"{len(scheduler.decode_scheduler.running) } \n"
-                    f"{len(scheduler.decode_scheduler.swapped) } \n"
+                    f"{len(scheduler.decode_scheduler.waiting) = } \n"
+                    f"{len(scheduler.decode_scheduler.running) = } \n"
+                    f"{len(scheduler.decode_scheduler.swapped) = } \n"
                     )
 
         prefill_future = None

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -79,7 +79,7 @@ class RequestTracker:
         self._request_streams: Dict[str, AsyncStream] = {}
         self._finished_requests: asyncio.Queue[str] = asyncio.Queue()
         self._new_requests: asyncio.Queue[Tuple[AsyncStream,
-        dict]] = asyncio.Queue()
+                                                dict]] = asyncio.Queue()
         self.new_requests_event = None
 
     def __contains__(self, item):
@@ -138,7 +138,7 @@ class RequestTracker:
         self._finished_requests.put_nowait(request_id)
 
         if request_id not in self._request_streams or self._request_streams[
-            request_id].finished:
+                request_id].finished:
             # The request has already finished or been aborted.
             return
 
@@ -206,8 +206,8 @@ class _AsyncLLMEngine(LLMEngine):
         return self._process_model_outputs(output, scheduler_outputs)
 
     async def _invoke_dist_workers(
-        self, dist_output: DistScheduleOutput,
-        is_prefill: bool) -> Tuple[List[RequestOutput], bool]:
+            self, dist_output: DistScheduleOutput,
+            is_prefill: bool) -> Tuple[List[RequestOutput], bool]:
 
         # See the DistScheduler.schedule() as of how the scheduling actually happened
         # to avoid complex prefill / decode communication logic.
@@ -308,7 +308,8 @@ class _AsyncLLMEngine(LLMEngine):
             else:
                 scheduler.on_decode_finish()
             result += output
-        logger.info(f"Finished step_dist_async() step {self.iteration_counter}.")
+        logger.info(
+            f"Finished step_dist_async() step {self.iteration_counter}.")
         logger.info(f"Obtain result: {result = }.")
 
         logger.info(f"Scheduler properties: "
@@ -317,9 +318,7 @@ class _AsyncLLMEngine(LLMEngine):
                     f"{scheduler._in_progress_prefill_requests = }."
                     f"{scheduler._in_progress_prefill_requests_metadatas = }."
                     f"{scheduler.prefill_memblocks = }."
-                    f"{scheduler.pending_migration_requests = }."
-                    )
-
+                    f"{scheduler.pending_migration_requests = }.")
 
         return result
 
@@ -566,7 +565,7 @@ class AsyncLLMEngine:
                     shortened_prompt = shortened_prompt[:self.max_log_len]
                 if shortened_token_ids is not None:
                     shortened_token_ids = shortened_token_ids[:self.
-                    max_log_len]
+                                                              max_log_len]
             logger.info(f"Received request {request_id}: "
                         f"prompt: {shortened_prompt!r}, "
                         f"prefix_pos: {prefix_pos},"

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -234,8 +234,9 @@ class _AsyncLLMEngine(LLMEngine):
                 "recv_blocks": dist_output.recv_blocks,
             }
             logger.info(
-                f"{'Prefill pool' if is_prefill else 'Decode pool' } invoking execute_model with {data = }."
+                f"{'Prefill pool' if is_prefill else 'Decode pool' } invoking execute_model with data: {data}"
             )
+
             all_outputs = await self._run_dist_worker_group_async(
                 worker_group,
                 "execute_model",

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -308,6 +308,18 @@ class _AsyncLLMEngine(LLMEngine):
             else:
                 scheduler.on_decode_finish()
             result += output
+        logger.info(f"Finished step_dist_async() step {self.iteration_counter}.")
+        logger.info(f"Obtain result: {result = }.")
+
+        logger.info(f"Scheduler properties: "
+                    f"{scheduler.is_prefill_in_progress = }, "
+                    f"{scheduler.is_decode_in_progress = }, "
+                    f"{scheduler._in_progress_prefill_requests = }."
+                    f"{scheduler._in_progress_prefill_requests_metadatas = }."
+                    f"{scheduler.prefill_memblocks = }."
+                    f"{scheduler.pending_migration_requests = }."
+                    )
+
 
         return result
 

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -249,10 +249,14 @@ class _AsyncLLMEngine(LLMEngine):
         assert isinstance(scheduler, DistScheduler)
 
         scheduler_outputs: DistScheduleOutput = scheduler.schedule()
-        prefill_future = self._invoke_dist_workers(scheduler_outputs,
-                                                   is_prefill=True)
-        decode_future = self._invoke_dist_workers(scheduler_outputs,
-                                                  is_prefill=False)
+        prefill_future = None
+        decode_future = None
+        if scheduler_outputs.prefill_metadata or scheduler_outputs.is_transfer_schedule:
+            prefill_future = self._invoke_dist_workers(scheduler_outputs,
+                                                       is_prefill=True)
+        if scheduler_outputs.decode_metadata or scheduler_outputs.is_transfer_schedule:
+            decode_future = self._invoke_dist_workers(scheduler_outputs,
+                                                      is_prefill=False)
 
         if prefill_future:
             self.pending_futures.add(prefill_future)

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -270,6 +270,7 @@ class _AsyncLLMEngine(LLMEngine):
             self.pending_futures, return_when=asyncio.FIRST_COMPLETED)
         self.pending_futures = pending
 
+        # FIXME: `finished` can be multiple - run a loop!!
         output, is_prefill = await finished.pop()
         if is_prefill:
             scheduler.on_prefill_finish()

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -641,11 +641,11 @@ class AsyncLLMEngine:
                 if shortened_token_ids is not None:
                     shortened_token_ids = shortened_token_ids[:self.
                                                               max_log_len]
-            logger.info(f"Received request {request_id}: "
-                        f"prompt: {shortened_prompt!r}, "
-                        f"prefix_pos: {prefix_pos},"
-                        f"sampling params: {sampling_params}, "
-                        f"prompt token ids: {shortened_token_ids}.")
+            # logger.info(f"Received request {request_id}: "
+            #             f"prompt: {shortened_prompt!r}, "
+            #             f"prefix_pos: {prefix_pos},"
+            #             f"sampling params: {sampling_params}, "
+            #             f"prompt token ids: {shortened_token_ids}.")
 
         if not self.is_running:
             if self.start_engine_loop:

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -228,6 +228,7 @@ class _AsyncLLMEngine(LLMEngine):
                 "blocks_to_swap_in": scheduler_outputs.blocks_to_swap_in,
                 "blocks_to_swap_out": scheduler_outputs.blocks_to_swap_out,
                 "blocks_to_copy": scheduler_outputs.blocks_to_copy,
+                # FIXME: Add transfer block event.
             }
             all_outputs = await self._run_dist_worker_group_async(
                 worker_group,
@@ -319,7 +320,6 @@ class _AsyncLLMEngine(LLMEngine):
         """Runs the given method on all workers in the given worker group."""
         assert self.parallel_config.is_disaggregate
 
-        coros = []
         if driver_args is None:
             driver_args = args
         if driver_kwargs is None:

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -766,8 +766,13 @@ class LLMEngine:
 
     def transfer_kv_cache(self, blocks_to_transfer: List[int]):
         # Invoke the transfer for each pipeline parallelism group.
+        # FIXME: The send_blocks and recv_blocks should be different,
+        #  and to-be allocated by the scheduler's block manager.
+        #  For simplicity, we ignore this part so far.
         self._run_workers("transfer_kv_cache",
-                          blocks_to_transfer=blocks_to_transfer)
+                          send_blocks=blocks_to_transfer,
+                          recv_blocks=blocks_to_transfer,
+                          )
         return
 
     def step(self) -> List[RequestOutput]:

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1081,4 +1081,4 @@ class LLMEngine:
         if has_error:
             raise Exception(
                 f"At execution of {method}, at least one worker failed.")
-        return outputs
+        return result

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -754,7 +754,7 @@ class LLMEngine:
         }
         worker_group = self.prefill_workers
         # worker_group = self.decode_workers
-        self.distribute_info(worker_group, data)
+        # self.distribute_info(worker_group, data)
 
         if not scheduler_outputs.is_empty():
             # Execute the model.
@@ -763,6 +763,7 @@ class LLMEngine:
             all_outputs = self._run_worker_group(
                 worker_group,
                 "execute_model",
+                **data
             )
 
             # Only the driver worker returns the sampling results.

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -804,9 +804,10 @@ class LLMEngine:
             "blocks_to_swap_out": scheduler_outputs.blocks_to_swap_out,
             "blocks_to_copy": scheduler_outputs.blocks_to_copy,
         }
-        worker_group = self.prefill_workers
-        # worker_group = self.decode_workers
-        # self.distribute_info(worker_group, data)
+        if self.parallel_config.is_disaggregate:
+            worker_group = self.prefill_workers
+        else:
+            worker_group = [self.driver_worker] + self.workers
 
         if not scheduler_outputs.is_empty():
             # Execute the model.

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -142,6 +142,7 @@ class LLMEngine:
         # Use for async to record the active working set
         # TODO: Rename to active_working_set? active_working_coros?
         self.pending_futures: Set[Coroutine] = set()
+        self.iteration_counter = 0
 
     def _init_workers(self):
         # Lazy import the Worker to avoid importing torch.cuda/xformers

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -776,7 +776,7 @@ class LLMEngine:
         """Distribute metadata info from driver process
         to the designated workers.
         """
-        self._run_worker_group(worker_group, "_hack_store_data", data)
+        self._run_worker_group(worker_group, "hack_store_data", data)
         return
 
     def do_log_stats(self) -> None:

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -760,11 +760,8 @@ class LLMEngine:
             # Execute the model.
             # TODO: (Question) why do we couple the data sending and model execution?
             #   For simplicity, can we just send the data to the workers then call "execute_model"?
-            all_outputs = self._run_worker_group(
-                worker_group,
-                "execute_model",
-                **data
-            )
+            all_outputs = self._run_worker_group(worker_group, "execute_model",
+                                                 **data)
 
             # Only the driver worker returns the sampling results.
             output = all_outputs[0]

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -115,7 +115,7 @@ class LLMEngine:
             N = self.parallel_config.tensor_parallel_size
             N = N - 1  # Excluding the driver worker, assuming driver worker works on prefill.
             prefill_workers, decode_workers = self.workers[:N], self.workers[
-                                                                N:]
+                N:]
             prefill_workers = [self.driver_worker] + prefill_workers
             self.prefill_workers, self.decode_workers = prefill_workers, decode_workers
             pass
@@ -672,8 +672,8 @@ class LLMEngine:
                 self.scheduler.free_seq(seq)
 
     def _process_model_outputs(
-        self, output: SamplerOutput,
-        scheduler_outputs: SchedulerOutputs) -> List[RequestOutput]:
+            self, output: SamplerOutput,
+            scheduler_outputs: SchedulerOutputs) -> List[RequestOutput]:
         # Update the scheduled sequence groups with the model outputs.
         scheduled_seq_groups = scheduler_outputs.scheduled_seq_groups
         for seq_group, outputs in zip(scheduled_seq_groups, output):
@@ -694,7 +694,7 @@ class LLMEngine:
         # Update prefix state, now all the uncomputed prefixes are computed.
         for seq_group in scheduled_seq_groups:
             if (seq_group.prefix is not None and seq_group.prefix.allocated
-                and not seq_group.prefix.computed):
+                    and not seq_group.prefix.computed):
                 seq_group.prefix.computed = True
 
         if self.log_stats:
@@ -741,9 +741,11 @@ class LLMEngine:
             worker.model_runner.is_driver_worker = True
             return
 
-        self._run_worker_group([worker_group[0]], "execute_lambda", set_leader_worker)
+        self._run_worker_group([worker_group[0]], "execute_lambda",
+                               set_leader_worker)
         while self.scheduler.has_unfinished_seqs():
-            seq_group_metadata_list, scheduler_outputs = self.scheduler.schedule()
+            seq_group_metadata_list, scheduler_outputs = self.scheduler.schedule(
+            )
             data = {
                 "seq_group_metadata_list": seq_group_metadata_list,
                 "blocks_to_swap_in": scheduler_outputs.blocks_to_swap_in,
@@ -925,14 +927,14 @@ class LLMEngine:
         """Decodes the new token for a sequence."""
         (new_tokens, new_output_text, prefix_offset,
          read_offset) = detokenize_incrementally(
-            self.tokenizer,
-            all_input_ids=seq.get_token_ids(),
-            prev_tokens=seq.tokens,
-            prefix_offset=seq.prefix_offset,
-            read_offset=seq.read_offset,
-            skip_special_tokens=prms.skip_special_tokens,
-            spaces_between_special_tokens=prms.spaces_between_special_tokens,
-        )
+             self.tokenizer,
+             all_input_ids=seq.get_token_ids(),
+             prev_tokens=seq.tokens,
+             prefix_offset=seq.prefix_offset,
+             read_offset=seq.read_offset,
+             skip_special_tokens=prms.skip_special_tokens,
+             spaces_between_special_tokens=prms.spaces_between_special_tokens,
+         )
         if seq.tokens is None:
             seq.tokens = new_tokens
         else:
@@ -968,7 +970,7 @@ class LLMEngine:
 
         # Check if the sequence has generated the EOS token.
         if ((not sampling_params.ignore_eos)
-            and seq.get_last_token_id() == self.tokenizer.eos_token_id):
+                and seq.get_last_token_id() == self.tokenizer.eos_token_id):
             seq.status = SequenceStatus.FINISHED_STOPPED
             return
 

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -986,8 +986,8 @@ class LLMEngine:
             _execute(worker, method, *args, **kwargs)
             for worker in rest_workers
         ]
-        driver_args = driver_args if driver_args is None else args
-        driver_kwargs = driver_kwargs if driver_kwargs is None else kwargs
+        driver_args = driver_args if driver_args is not None else args
+        driver_kwargs = driver_kwargs if driver_kwargs is not None else kwargs
 
         # Start the lead worker after all the ray workers.
         lead_worker_output = _execute(lead_worker, method, *driver_args,

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -143,6 +143,7 @@ class LLMEngine:
         # TODO: Rename to active_working_set? active_working_coros?
         self.pending_futures: Set[Coroutine] = set()
         self.iteration_counter = 0
+        self.event_logging = {}  # (start_time, end_time, duration, task_name)
 
     def _init_workers(self):
         # Lazy import the Worker to avoid importing torch.cuda/xformers

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -714,6 +714,8 @@ class LLMEngine:
         return request_outputs
 
     def run_engine_disaggregate(self):
+        # This is assuming using the old scheduler not the new DistScheduler.
+        assert isinstance(self.scheduler, Scheduler)
         results = []
 
         # Run one prefill.

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -770,13 +770,6 @@ class LLMEngine:
 
         return self._process_model_outputs(output, scheduler_outputs)
 
-    def distribute_info(self, worker_group, data):
-        """Distribute metadata info from driver process
-        to the designated workers.
-        """
-        self._run_worker_group(worker_group, "hack_store_data", data)
-        return
-
     def do_log_stats(self) -> None:
         self._log_system_stats(False, 0)
 

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -769,10 +769,11 @@ class LLMEngine:
         # FIXME: The send_blocks and recv_blocks should be different,
         #  and to-be allocated by the scheduler's block manager.
         #  For simplicity, we ignore this part so far.
-        self._run_workers("transfer_kv_cache",
-                          send_blocks=blocks_to_transfer,
-                          recv_blocks=blocks_to_transfer,
-                          )
+        self._run_workers(
+            "transfer_kv_cache",
+            send_blocks=blocks_to_transfer,
+            recv_blocks=blocks_to_transfer,
+        )
         return
 
     def step(self) -> List[RequestOutput]:

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -737,7 +737,7 @@ class LLMEngine:
 
         # Make the leader worker the driver worker.
         def set_leader_worker(worker):
-            worker.is_driver_worker = True
+            # worker.is_driver_worker = True
             worker.model_runner.is_driver_worker = True
             return
 

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -755,9 +755,9 @@ class LLMEngine:
             output = all_outputs[0]
             step_output = self._process_model_outputs(output,
                                                       scheduler_outputs)
-            for _output in step_output:
-                if _output.finished:
-                    results.append(output)
+            for item in step_output:
+                if item.finished:
+                    results.append(item)
 
         results = sorted(results, key=lambda x: int(x.request_id))
         return results

--- a/vllm/engine/ray_utils.py
+++ b/vllm/engine/ray_utils.py
@@ -25,6 +25,10 @@ try:
         def __getattr__(self, name):
             return getattr(self.worker, name)
 
+        # FIXME: (hack) SHOULD NOT BE IN MASTER!
+        def execute_lambda(self, lambda_fn, *args, **kwargs):
+            return lambda_fn(self.worker, *args, **kwargs)
+
         def execute_method(self, method, *args, **kwargs):
             executor = getattr(self, method)
             return executor(*args, **kwargs)

--- a/vllm/engine/ray_utils.py
+++ b/vllm/engine/ray_utils.py
@@ -80,11 +80,22 @@ def initialize_cluster(
                 "serving.")
         # Connect to a ray cluster.
         if is_hip():
-            ray.init(address=ray_address,
-                     ignore_reinit_error=True,
-                     num_gpus=parallel_config.world_size)
+            ray.init(
+                address=ray_address,
+                ignore_reinit_error=True,
+                num_gpus=parallel_config.world_size,
+                local_mode=
+                True,  # FIXME: (hack) SHOULD NOT BE IN MASTER! - enable debug
+            )
+            logger.debug(f"Ray init with debugging enabled: {ray_address}")
         else:
-            ray.init(address=ray_address, ignore_reinit_error=True)
+            ray.init(
+                address=ray_address,
+                ignore_reinit_error=True,
+                local_mode=
+                True,  # FIXME: (hack) SHOULD NOT BE IN MASTER! - enable debug
+            )
+            logger.debug(f"Ray init with debugging enabled: {ray_address}")
 
     if not parallel_config.worker_use_ray:
         assert parallel_config.world_size == 1, (

--- a/vllm/engine/ray_utils.py
+++ b/vllm/engine/ray_utils.py
@@ -84,16 +84,16 @@ def initialize_cluster(
                 address=ray_address,
                 ignore_reinit_error=True,
                 num_gpus=parallel_config.world_size,
-                local_mode=
-                True,  # FIXME: (hack) SHOULD NOT BE IN MASTER! - enable debug
+                # local_mode=
+                # True,  # FIXME: (hack) SHOULD NOT BE IN MASTER! - enable debug
             )
             logger.debug(f"Ray init with debugging enabled: {ray_address}")
         else:
             ray.init(
                 address=ray_address,
                 ignore_reinit_error=True,
-                local_mode=
-                True,  # FIXME: (hack) SHOULD NOT BE IN MASTER! - enable debug
+                # local_mode=
+                # True,  # FIXME: (hack) SHOULD NOT BE IN MASTER! - enable debug
             )
             logger.debug(f"Ray init with debugging enabled: {ray_address}")
 

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -83,6 +83,8 @@ class LLM:
         max_context_len_to_capture: int = 8192,
         is_disaggregate: bool = False,
         pipeline_parallel_size: int = 1,
+        is_dummy_llm:
+        bool = False,  # FIXME: (Hack) do not let llm engine initialized
         **kwargs,
     ) -> None:
         if "disable_log_stats" not in kwargs:
@@ -106,8 +108,11 @@ class LLM:
             pipeline_parallel_size=pipeline_parallel_size,
             **kwargs,
         )
-        self.llm_engine = LLMEngine.from_engine_args(engine_args)
+        self.engine_args = engine_args
         self.request_counter = Counter()
+        if is_dummy_llm:
+            return
+        self.llm_engine = LLMEngine.from_engine_args(engine_args)
 
     def get_tokenizer(
             self) -> Union[PreTrainedTokenizer, PreTrainedTokenizerFast]:

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -1,3 +1,4 @@
+import time
 from typing import List, Optional, Union
 
 from tqdm import tqdm
@@ -116,7 +117,7 @@ class LLM:
         self.llm_engine = LLMEngine.from_engine_args(engine_args)
 
     def get_tokenizer(
-            self) -> Union[PreTrainedTokenizer, PreTrainedTokenizerFast]:
+        self) -> Union[PreTrainedTokenizer, PreTrainedTokenizerFast]:
         return self.llm_engine.tokenizer
 
     def set_tokenizer(
@@ -163,7 +164,7 @@ class LLM:
             # Convert a single prompt to a list.
             prompts = [prompts]
         if (prompts is not None and prompt_token_ids is not None
-                and len(prompts) != len(prompt_token_ids)):
+            and len(prompts) != len(prompt_token_ids)):
             raise ValueError("The lengths of prompts and prompt_token_ids "
                              "must be the same.")
         if sampling_params is None:
@@ -208,8 +209,11 @@ class LLM:
         step_counter = 0
         while self.llm_engine.has_unfinished_requests():
             logger.info(f"Running {step_counter = }.")
+            start_time = time.perf_counter()
             step_outputs = self.llm_engine.step()
-            logger.info(f"Finish running {step_counter = }.")
+            end_time = time.perf_counter()
+            duration = end_time - start_time
+            logger.info(f"Finish running {step_counter = } in {(duration * 1000):.2f} ms.")
             step_counter += 1
             for output in step_outputs:
                 if output.finished:

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -169,7 +169,10 @@ class LLM:
             token_ids = None if prompt_token_ids is None else prompt_token_ids[
                 i]
             self._add_request(prompt, sampling_params, token_ids, prefix_pos_i)
-        return self._run_engine(use_tqdm)
+        if self.llm_engine.parallel_config.is_disaggregate:
+            return self._run_engine_disaggregate(use_tqdm)
+        else:
+            return self._run_engine(use_tqdm)
 
     def _add_request(
         self,
@@ -206,3 +209,6 @@ class LLM:
         # its previous requests.
         outputs = sorted(outputs, key=lambda x: int(x.request_id))
         return outputs
+
+    def _run_engine_disaggregate(self, use_tqdm: bool) -> List[RequestOutput]:
+        return self.llm_engine.run_engine_disaggregate()

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -5,7 +5,7 @@ from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
 
 from vllm import AsyncLLMEngine
 from vllm.engine.arg_utils import EngineArgs
-from vllm.engine.llm_engine import LLMEngine
+from vllm.engine.llm_engine import LLMEngine, logger
 from vllm.outputs import RequestOutput
 from vllm.sampling_params import SamplingParams
 from vllm.utils import Counter
@@ -205,8 +205,12 @@ class LLM:
             pbar = tqdm(total=num_requests, desc="Processed prompts")
         # Run the engine.
         outputs: List[RequestOutput] = []
+        step_counter = 0
         while self.llm_engine.has_unfinished_requests():
+            logger.info(f"Running {step_counter = }.")
             step_outputs = self.llm_engine.step()
+            logger.info(f"Finish running {step_counter = }.")
+            step_counter += 1
             for output in step_outputs:
                 if output.finished:
                     outputs.append(output)

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -117,7 +117,7 @@ class LLM:
         self.llm_engine = LLMEngine.from_engine_args(engine_args)
 
     def get_tokenizer(
-        self) -> Union[PreTrainedTokenizer, PreTrainedTokenizerFast]:
+            self) -> Union[PreTrainedTokenizer, PreTrainedTokenizerFast]:
         return self.llm_engine.tokenizer
 
     def set_tokenizer(
@@ -164,7 +164,7 @@ class LLM:
             # Convert a single prompt to a list.
             prompts = [prompts]
         if (prompts is not None and prompt_token_ids is not None
-            and len(prompts) != len(prompt_token_ids)):
+                and len(prompts) != len(prompt_token_ids)):
             raise ValueError("The lengths of prompts and prompt_token_ids "
                              "must be the same.")
         if sampling_params is None:
@@ -213,7 +213,9 @@ class LLM:
             step_outputs = self.llm_engine.step()
             end_time = time.perf_counter()
             duration = end_time - start_time
-            logger.info(f"Finish running {step_counter = } in {(duration * 1000):.2f} ms.")
+            logger.info(
+                f"Finish running {step_counter = } in {(duration * 1000):.2f} ms."
+            )
             step_counter += 1
             for output in step_outputs:
                 if output.finished:

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -81,6 +81,8 @@ class LLM:
         swap_space: int = 4,
         enforce_eager: bool = False,
         max_context_len_to_capture: int = 8192,
+        is_disaggregate: bool = False,
+        pipeline_parallel_size: int = 1,
         **kwargs,
     ) -> None:
         if "disable_log_stats" not in kwargs:
@@ -100,6 +102,8 @@ class LLM:
             swap_space=swap_space,
             enforce_eager=enforce_eager,
             max_context_len_to_capture=max_context_len_to_capture,
+            is_disaggregate=is_disaggregate,
+            pipeline_parallel_size=pipeline_parallel_size,
             **kwargs,
         )
         self.llm_engine = LLMEngine.from_engine_args(engine_args)

--- a/vllm/logger.py
+++ b/vllm/logger.py
@@ -4,8 +4,8 @@
 import logging
 import sys
 
-_FORMAT = "%(levelname)s %(asctime)s %(filename)s:%(lineno)d] %(message)s"
-_DATE_FORMAT = "%m-%d %H:%M:%S.%f"
+_FORMAT = "%(levelname)s %(asctime)s.%(msecs)03d %(filename)s:%(lineno)d] %(message)s"
+_DATE_FORMAT = "%m-%d %H:%M:%S"
 
 
 class NewLineFormatter(logging.Formatter):

--- a/vllm/logger.py
+++ b/vllm/logger.py
@@ -5,7 +5,7 @@ import logging
 import sys
 
 _FORMAT = "%(levelname)s %(asctime)s %(filename)s:%(lineno)d] %(message)s"
-_DATE_FORMAT = "%m-%d %H:%M:%S"
+_DATE_FORMAT = "%m-%d %H:%M:%S.%f"
 
 
 class NewLineFormatter(logging.Formatter):

--- a/vllm/model_executor/model_loader.py
+++ b/vllm/model_executor/model_loader.py
@@ -35,6 +35,8 @@ def _get_model_architecture(config: PretrainedConfig) -> Type[nn.Module]:
 def get_model(model_config: ModelConfig) -> nn.Module:
     model_class = _get_model_architecture(model_config.hf_config)
 
+    print(
+        f"{__file__} - model_config.quantization: {model_config.quantization}")
     # Get the (maybe quantized) linear method.
     linear_method = None
     if model_config.quantization is not None:
@@ -58,11 +60,15 @@ def get_model(model_config: ModelConfig) -> nn.Module:
                 f"{supported_dtypes}")
         linear_method = quant_config.get_linear_method()
 
+    print(f"{__file__} - model_config.dtype: {model_config.dtype}")
     with _set_default_torch_dtype(model_config.dtype):
         # Create a model instance.
         # The weights will be initialized as empty tensors.
         with torch.device("cuda"):
+            print(f"{__file__} - Ready to load model class.")
             model = model_class(model_config.hf_config, linear_method)
+
+        print(f"{__file__} - Ready to load weights.")
         if model_config.load_format == "dummy":
             # NOTE(woosuk): For accurate performance evaluation, we assign
             # random values to the weights.

--- a/vllm/model_executor/parallel_utils/communication_op.py
+++ b/vllm/model_executor/parallel_utils/communication_op.py
@@ -16,7 +16,9 @@ from vllm.model_executor.parallel_utils.parallel_state import (
 @contextlib.contextmanager
 def log_calling_method(method_name):
     """Log the calling method."""
+    yield
     return
+    
     print(f"Calling {method_name} ...")
     yield
     print(f"Finished {method_name} ...")

--- a/vllm/model_executor/parallel_utils/communication_op.py
+++ b/vllm/model_executor/parallel_utils/communication_op.py
@@ -54,9 +54,10 @@ def tensor_model_parallel_all_gather(input_: torch.Tensor,
     return output_tensor
 
 
-def tensor_model_parallel_gather(input_: torch.Tensor,
-                                 dst: int = 0,  # local rank
-                                 dim: int = -1) -> torch.Tensor:
+def tensor_model_parallel_gather(
+        input_: torch.Tensor,
+        dst: int = 0,  # local rank
+        dim: int = -1) -> torch.Tensor:
     """Gather the input tensor across model parallel group.
 
     NOTE: We assume that the input tensor is on the same device across

--- a/vllm/model_executor/parallel_utils/communication_op.py
+++ b/vllm/model_executor/parallel_utils/communication_op.py
@@ -1,3 +1,4 @@
+import contextlib
 from collections import namedtuple
 from typing import Any, Dict, List, Optional, Union
 
@@ -12,6 +13,15 @@ from vllm.model_executor.parallel_utils.parallel_state import (
 )
 
 
+@contextlib.contextmanager
+def log_calling_method(method_name):
+    """Log the calling method."""
+    print(f"Calling {method_name} ...")
+    yield
+    print(f"Finished {method_name} ...")
+
+
+@log_calling_method("tensor_model_parallel_all_reduce")
 def tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     """All-reduce the input tensor across model parallel group.
 
@@ -26,6 +36,7 @@ def tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     return input_
 
 
+@log_calling_method("tensor_model_parallel_all_gather")
 def tensor_model_parallel_all_gather(input_: torch.Tensor,
                                      dim: int = -1) -> torch.Tensor:
     """All-gather the input tensor across model parallel group."""
@@ -54,6 +65,7 @@ def tensor_model_parallel_all_gather(input_: torch.Tensor,
     return output_tensor
 
 
+@log_calling_method("tensor_model_parallel_gather")
 def tensor_model_parallel_gather(
         input_: torch.Tensor,
         dst: int = 0,  # local rank
@@ -94,6 +106,7 @@ def tensor_model_parallel_gather(
     return output_tensor
 
 
+@log_calling_method("tensor_model_parallel_scatter")
 def broadcast(input_: torch.Tensor,
               src: int = 0,
               group: Optional[ProcessGroup] = None):
@@ -111,6 +124,7 @@ def broadcast(input_: torch.Tensor,
     return input_
 
 
+@log_calling_method("tensor_model_parallel_broadcast")
 def broadcast_object_list(obj_list: List[Any],
                           src: int = 0,
                           group: Optional[ProcessGroup] = None):
@@ -131,6 +145,7 @@ def broadcast_object_list(obj_list: List[Any],
 TensorMetadata = namedtuple("TensorMetadata", ["dtype", "size"])
 
 
+@log_calling_method("broadcast_tensor_dict")
 def broadcast_tensor_dict(
     tensor_dict: Optional[Dict[Any, Union[torch.Tensor, Any]]] = None,
     src: int = 0,

--- a/vllm/model_executor/parallel_utils/communication_op.py
+++ b/vllm/model_executor/parallel_utils/communication_op.py
@@ -16,6 +16,7 @@ from vllm.model_executor.parallel_utils.parallel_state import (
 @contextlib.contextmanager
 def log_calling_method(method_name):
     """Log the calling method."""
+    return
     print(f"Calling {method_name} ...")
     yield
     print(f"Finished {method_name} ...")

--- a/vllm/model_executor/parallel_utils/communication_op.py
+++ b/vllm/model_executor/parallel_utils/communication_op.py
@@ -18,7 +18,7 @@ def log_calling_method(method_name):
     """Log the calling method."""
     yield
     return
-    
+
     print(f"Calling {method_name} ...")
     yield
     print(f"Finished {method_name} ...")

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -220,6 +220,8 @@ class Sequence:
                 f"status={self.status.name}, "
                 f"num_blocks={len(self.logical_token_blocks)})")
 
+    __str__ = __repr__
+
 
 class SequenceGroup:
     """A group of sequences that are generated from the same prompt.
@@ -327,6 +329,8 @@ class SequenceGroup:
                 f"sampling_params={self.sampling_params}, "
                 f"num_seqs={len(self.seqs_dict)})")
 
+    __str__ = __repr__
+
 
 class SequenceGroupMetadata:
     """Metadata for a sequence group. Used to create `InputMetadata`.
@@ -356,6 +360,16 @@ class SequenceGroupMetadata:
         self.sampling_params = sampling_params
         self.block_tables = block_tables
         self.prefix = prefix
+
+    def __repr__(self):
+        return (f"SequenceGroupMetadata(request_id={self.request_id}, "
+                f"is_prompt={self.is_prompt}, "
+                f"seq_data={self.seq_data}, "
+                f"sampling_params={self.sampling_params}, "
+                f"block_tables={self.block_tables}, "
+                f"prefix={self.prefix})")
+
+    __str__ = __repr__
 
 
 class SequenceOutput:

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -65,7 +65,7 @@ class SequenceData:
         self,
         prompt_token_ids: List[int],
     ) -> None:
-        self.prompt_token_ids = prompt_token_ids
+        self.prompt_token_ids: List[int] = prompt_token_ids
         self.output_token_ids: List[int] = []
         self.cumulative_logprob = 0.0
 
@@ -115,18 +115,18 @@ class Sequence:
         prompt_token_ids: List[int],
         block_size: int,
     ) -> None:
-        self.seq_id = seq_id
-        self.prompt = prompt
-        self.block_size = block_size
+        self.seq_id: int = seq_id
+        self.prompt: str = prompt
+        self.block_size: int = block_size
 
-        self.data = SequenceData(prompt_token_ids)
+        self.data: SequenceData = SequenceData(prompt_token_ids)
         self.output_logprobs: SampleLogprobs = []
-        self.output_text = ""
+        self.output_text: str = ""
 
         self.logical_token_blocks: List[LogicalTokenBlock] = []
         # Initialize the logical token blocks with the prompt token ids.
         self._append_tokens_to_blocks(prompt_token_ids)
-        self.status = SequenceStatus.WAITING
+        self.status: SequenceStatus = SequenceStatus.WAITING
 
         # Used for incremental detokenization
         self.prefix_offset = 0
@@ -244,8 +244,8 @@ class SequenceGroup:
     ) -> None:
         self.request_id: str = request_id
         self.seqs_dict: Dict[int, Sequence] = {seq.seq_id: seq for seq in seqs}
-        self.sampling_params = sampling_params
-        self.arrival_time = arrival_time
+        self.sampling_params: SamplingParams = sampling_params
+        self.arrival_time: float = arrival_time
         self.prefix: Optional[Prefix] = prefix
         self.prompt_logprobs: Optional[PromptLogprobs] = None
 
@@ -361,12 +361,12 @@ class SequenceGroupMetadata:
         block_tables: Dict[int, List[int]],
         prefix: Optional[Prefix] = None,
     ) -> None:
-        self.request_id = request_id
-        self.is_prompt = is_prompt
-        self.seq_data = seq_data
+        self.request_id: str = request_id
+        self.is_prompt: bool = is_prompt
+        self.seq_data: Dict[int, SequenceData] = seq_data
         self.sampling_params = sampling_params
-        self.block_tables = block_tables
-        self.prefix = prefix
+        self.block_tables: Dict[int, List[int]] = block_tables
+        self.prefix: Optional[Prefix] = prefix
 
     def __repr__(self):
         return (f"SequenceGroupMetadata(request_id={self.request_id}, "
@@ -421,8 +421,8 @@ class SequenceGroupOutput:
         samples: List[SequenceOutput],
         prompt_logprobs: Optional[PromptLogprobs],
     ) -> None:
-        self.samples = samples
-        self.prompt_logprobs = prompt_logprobs
+        self.samples: List[SequenceOutput] = samples
+        self.prompt_logprobs: Optional[PromptLogprobs] = prompt_logprobs
 
     def __repr__(self) -> str:
         return (f"SequenceGroupOutput(samples={self.samples}, "

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -262,7 +262,6 @@ class SequenceGroup:
             )
             self.seqs_dict[key] = new_seq
 
-
         return
 
     @property

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -242,12 +242,19 @@ class SequenceGroup:
         arrival_time: float,
         prefix: Optional[Prefix] = None,
     ) -> None:
-        self.request_id = request_id
-        self.seqs_dict = {seq.seq_id: seq for seq in seqs}
+        self.request_id: str = request_id
+        self.seqs_dict: Dict[int, Sequence] = {seq.seq_id: seq for seq in seqs}
         self.sampling_params = sampling_params
         self.arrival_time = arrival_time
         self.prefix: Optional[Prefix] = prefix
         self.prompt_logprobs: Optional[PromptLogprobs] = None
+
+    def hacky_rewind(self, status: SequenceStatus) -> None:
+        # FIXME: Hack the sequence group to rewind every sequence back to a certain state.
+        """Rewind the sequence group to the state."""
+        for _, seq in self.seqs_dict.items():
+            seq.status = status
+        return
 
     @property
     def prompt(self) -> str:

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -249,11 +249,20 @@ class SequenceGroup:
         self.prefix: Optional[Prefix] = prefix
         self.prompt_logprobs: Optional[PromptLogprobs] = None
 
-    def hacky_rewind(self, status: SequenceStatus) -> None:
+    def hacky_rewind(self) -> None:
         # FIXME: Hack the sequence group to rewind every sequence back to a certain state.
         """Rewind the sequence group to the state."""
-        for _, seq in self.seqs_dict.items():
-            seq.status = status
+        for key, seq in self.seqs_dict.items():
+            assert isinstance(seq, Sequence)
+            new_seq = Sequence(
+                seq_id=seq.seq_id,
+                prompt=seq.prompt,
+                prompt_token_ids=seq.data.prompt_token_ids,
+                block_size=seq.block_size,
+            )
+            self.seqs_dict[key] = new_seq
+
+
         return
 
     @property

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -82,5 +82,6 @@ def set_cuda_visible_devices(device_ids: List[int]) -> None:
 
 # debug_pront = print
 debug_pront = lambda *_, **__: None
+debug_pront_2 = lambda *_, **__: None
 # debug_slept = time.sleep
 debug_slept = lambda *_, **__: None

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -83,5 +83,19 @@ def set_cuda_visible_devices(device_ids: List[int]) -> None:
 # debug_pront = print
 debug_pront = lambda *_, **__: None
 debug_pront_2 = lambda *_, **__: None
+
+logger_g = None
+
+
+# debug_pront_3 = lambda *_, **__: None
+def debug_pront_3(*args, **kwargs):
+    global logger_g
+    if not logger_g:
+        from vllm.logger import init_logger
+        logger_g = init_logger(__name__)
+    logger_g.debug(*args, **kwargs)
+    return
+
+
 # debug_slept = time.sleep
 debug_slept = lambda *_, **__: None

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -93,7 +93,7 @@ def debug_pront_3(*args, **kwargs):
     if not logger_g:
         from vllm.logger import init_logger
         logger_g = init_logger(__name__)
-    logger_g.debug(*args, **kwargs)
+    logger_g.info(*args, **kwargs)
     return
 
 

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -99,3 +99,44 @@ def debug_pront_3(*args, **kwargs):
 
 # debug_slept = time.sleep
 debug_slept = lambda *_, **__: None
+
+
+def tensor_size_in_bytes(tensor):
+    """
+    Calculate the size of a tensor in bytes.
+
+    Args:
+    tensor (torch.Tensor): The tensor for which to calculate the size.
+
+    Returns:
+    int: The size of the tensor in bytes.
+    """
+    return tensor.nelement() * tensor.element_size()
+
+
+def human_readable_size(size_in_bytes):
+    """
+    Convert a size in bytes to a human readable string.
+
+    Args:
+    size_in_bytes (int): The size in bytes.
+
+    Returns:
+    str: The human readable size.
+    """
+    if size_in_bytes < 1024:
+        return f"{size_in_bytes} B"
+    elif size_in_bytes < 1024 ** 2:
+        return f"{size_in_bytes / 1024:.2f} KB"
+    elif size_in_bytes < 1024 ** 3:
+        return f"{size_in_bytes / 1024 ** 2:.2f} MB"
+    elif size_in_bytes < 1024 ** 4:
+        return f"{size_in_bytes / 1024 ** 3:.2f} GB"
+    elif size_in_bytes < 1024 ** 5:
+        return f"{size_in_bytes / 1024 ** 4:.2f} TB"
+    else:
+        return f"{size_in_bytes / 1024 ** 5:.2f} PB"
+
+
+def tensor_size_in_bytes_human_readable(tensor):
+    return human_readable_size(tensor_size_in_bytes(tensor))

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -126,13 +126,13 @@ def human_readable_size(size_in_bytes):
     """
     if size_in_bytes < 1024:
         return f"{size_in_bytes} B"
-    elif size_in_bytes < 1024 ** 2:
+    elif size_in_bytes < 1024**2:
         return f"{size_in_bytes / 1024:.2f} KB"
-    elif size_in_bytes < 1024 ** 3:
+    elif size_in_bytes < 1024**3:
         return f"{size_in_bytes / 1024 ** 2:.2f} MB"
-    elif size_in_bytes < 1024 ** 4:
+    elif size_in_bytes < 1024**4:
         return f"{size_in_bytes / 1024 ** 3:.2f} GB"
-    elif size_in_bytes < 1024 ** 5:
+    elif size_in_bytes < 1024**5:
         return f"{size_in_bytes / 1024 ** 4:.2f} TB"
     else:
         return f"{size_in_bytes / 1024 ** 5:.2f} PB"

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -1,6 +1,7 @@
 import enum
 import os
 import socket
+import time
 import uuid
 from platform import uname
 from typing import List
@@ -77,3 +78,9 @@ def get_open_port() -> int:
 
 def set_cuda_visible_devices(device_ids: List[int]) -> None:
     os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(map(str, device_ids))
+
+
+# debug_pront = print
+debug_pront = lambda *_, **__: None
+# debug_slept = time.sleep
+debug_slept = lambda *_, **__: None

--- a/vllm/worker/cache_engine.py
+++ b/vllm/worker/cache_engine.py
@@ -211,26 +211,6 @@ class CacheEngine:
         # Call the kernel
         x = 16 // torch.tensor([], dtype=self.dtype).element_size()
 
-
-        debug_pront_3(
-            f"Calling cache_ops.retrieve_blocks() with "
-            f"{self.num_layers = }, {self.num_gpu_blocks = }, {self.num_heads = }, "
-            f"{self.head_size = }, {self.block_size = }, {x = }, "
-            f"{decoding_tp_rank = }, {src_block_ids = }, {dst_block_ids = }, "
-            f"{decoding_worker_k_caches = }, {decoding_worker_v_caches = }"
-        )
-
-        debug_pront_3(
-            f"Each has type "
-            f"{type(self.num_layers) = }, {type(self.num_gpu_blocks) = }, {type(self.num_heads) = }, "
-            f"{type(self.head_size) = }, {type(self.block_size) = }, {type(x) = }, "
-            f"{type(decoding_tp_rank) = }, {type(src_block_ids) = }, {type(dst_block_ids) = }, "
-            f"{type(decoding_worker_k_caches) = }, {type(decoding_worker_v_caches) = }"
-            f"{type(decoding_worker_k_caches[0]) = }, {type(decoding_worker_v_caches[0]) = }"
-        )
-
-
-        time.sleep(10)
         cache_ops.migrate_blocks(
             int(self.num_layers),
             int(self.num_gpu_blocks),

--- a/vllm/worker/cache_engine.py
+++ b/vllm/worker/cache_engine.py
@@ -45,7 +45,7 @@ class CacheEngine:
         self.num_cpu_blocks = cache_config.num_cpu_blocks
 
         # Initialize the cache.
-        self.gpu_cache = self.allocate_gpu_cache()
+        self.gpu_cache: List[KVCache] = self.allocate_gpu_cache()
         self.cpu_cache = self.allocate_cpu_cache()
 
         # Initialize the stream for caching operations.
@@ -210,13 +210,34 @@ class CacheEngine:
 
         # Call the kernel
         x = 16 // torch.tensor([], dtype=self.dtype).element_size()
+
+
+        debug_pront_3(
+            f"Calling cache_ops.retrieve_blocks() with "
+            f"{self.num_layers = }, {self.num_gpu_blocks = }, {self.num_heads = }, "
+            f"{self.head_size = }, {self.block_size = }, {x = }, "
+            f"{decoding_tp_rank = }, {src_block_ids = }, {dst_block_ids = }, "
+            f"{decoding_worker_k_caches = }, {decoding_worker_v_caches = }"
+        )
+
+        debug_pront_3(
+            f"Each has type "
+            f"{type(self.num_layers) = }, {type(self.num_gpu_blocks) = }, {type(self.num_heads) = }, "
+            f"{type(self.head_size) = }, {type(self.block_size) = }, {type(x) = }, "
+            f"{type(decoding_tp_rank) = }, {type(src_block_ids) = }, {type(dst_block_ids) = }, "
+            f"{type(decoding_worker_k_caches) = }, {type(decoding_worker_v_caches) = }"
+            f"{type(decoding_worker_k_caches[0]) = }, {type(decoding_worker_v_caches[0]) = }"
+        )
+
+
+        time.sleep(10)
         cache_ops.migrate_blocks(
-            self.num_layers,
-            self.num_gpu_blocks,
-            self.num_heads,
-            self.head_size,
-            self.block_size,
-            x,
+            int(self.num_layers),
+            int(self.num_gpu_blocks),
+            int(self.num_heads),
+            int(self.head_size),
+            int(self.block_size),
+            int(x),
             decoding_tp_rank,
             src_block_ids,
             dst_block_ids,

--- a/vllm/worker/cache_engine.py
+++ b/vllm/worker/cache_engine.py
@@ -143,10 +143,10 @@ class CacheEngine:
         tasks = []
         rank = get_pipeline_model_parallel_next_rank()
         start_time = time.time()
-        debug_pront_3(f"Sending blocks {block_ids = } to {rank = }")
+        debug_pront_3(f"Sending blocks {len(block_ids) = } to {rank = }")
         for block_id in block_ids:
             for i in range(self.num_layers):
-                debug_pront(f"Sending block: {block_id} from layer {i}")
+                debug_pront_3(f"Sending block: {block_id} from layer {i}")
                 for j in [0, 1]:
                     a = self.gpu_cache[i][j][block_id]
                     x = torch.distributed.isend(a, dst=rank)
@@ -158,29 +158,31 @@ class CacheEngine:
         end_time = time.time()
         duration = end_time - start_time
         duration *= 1000
-        debug_pront_3(f"Done sending blocks {block_ids = } to {rank = } in {duration} ms")
+        debug_pront_3(f"Done sending blocks {len(block_ids) = } to {rank = } in {duration} ms")
         return
 
     def recv_blocks(self, block_ids: List[int]) -> None:
         tasks = []
         rank = get_pipeline_model_parallel_prev_rank()
         start_time = time.time()
-        debug_pront_3(f"Receiving blocks {block_ids = } from {rank = }")
+        # debug_pront_3(f"Receiving blocks {block_ids = } from {rank = }")
+        debug_pront_3(f"Receiving blocks {len(block_ids) = } from {rank = }")
         for block_id in block_ids:
             for i in range(self.num_layers):
-                debug_pront(f"Receiving block: {block_id} from layer {i}")
+                debug_pront_3(f"Receiving block: {block_id} from layer {i}")
                 for j in [0, 1]:
                     a = self.gpu_cache[i][j][block_id]
                     x = torch.distributed.irecv(a, src=rank)
                     tasks.append(x)
                 pass
         for i, task in enumerate(tasks):
-            debug_pront(f"Waiting for task: {i}")
+            debug_pront_3(f"Waiting for task: {i}")
             task.wait()
+            debug_pront_3(f"Finish waiting for task: {i}")
         end_time = time.time()
         duration = end_time - start_time
         duration *= 1000
-        debug_pront_3(f"Done receiving blocks {block_ids = } from {rank = } in {duration} ms")
+        debug_pront_3(f"Done receiving blocks {len(block_ids) = } from {rank = } in {duration} ms")
         return
 
     def copy(self, src_to_dsts: Dict[int, List[int]]) -> None:

--- a/vllm/worker/cache_engine.py
+++ b/vllm/worker/cache_engine.py
@@ -9,7 +9,7 @@ from vllm.config import CacheConfig, ModelConfig, ParallelConfig
 from vllm.logger import init_logger
 from vllm.model_executor.parallel_utils.parallel_state import get_pipeline_model_parallel_next_rank, \
     get_pipeline_model_parallel_prev_rank
-from vllm.utils import in_wsl, debug_pront, debug_pront_3, tensor_size_in_bytes
+from vllm.utils import in_wsl, debug_pront, debug_pront_3, tensor_size_in_bytes, human_readable_size
 
 logger = init_logger(__name__)
 
@@ -160,6 +160,7 @@ class CacheEngine:
         end_time = time.time()
         duration = end_time - start_time
         duration *= 1000
+        total_size = human_readable_size(total_size)
         debug_pront_3(f"Done sending blocks {len(block_ids) = } ({total_size = }) to {rank = } in {duration} ms")
         return
 
@@ -182,6 +183,7 @@ class CacheEngine:
         end_time = time.time()
         duration = end_time - start_time
         duration *= 1000
+        total_size = human_readable_size(total_size)
         debug_pront_3(f"Done receiving (irecv) blocks {len(block_ids) = } ({total_size = }) from {rank = } in {duration} ms")
         for i, task in enumerate(tasks):
             task.wait()

--- a/vllm/worker/cache_engine.py
+++ b/vllm/worker/cache_engine.py
@@ -147,7 +147,7 @@ class CacheEngine:
         total_size = 0
         for block_id in block_ids:
             for i in range(self.num_layers):
-                debug_pront_3(f"Sending block: {block_id} from layer {i}")
+                # debug_pront_3(f"Sending block: {block_id} from layer {i}")
                 for j in [0, 1]:
                     a = self.gpu_cache[i][j][block_id]
                     x = torch.distributed.isend(a, dst=rank)
@@ -172,7 +172,7 @@ class CacheEngine:
         total_size = 0
         for block_id in block_ids:
             for i in range(self.num_layers):
-                debug_pront_3(f"Receiving block: {block_id} from layer {i}")
+                # debug_pront_3(f"Receiving block: {block_id} from layer {i}")
                 for j in [0, 1]:
                     a = self.gpu_cache[i][j][block_id]
                     x = torch.distributed.irecv(a, src=rank)

--- a/vllm/worker/cache_engine.py
+++ b/vllm/worker/cache_engine.py
@@ -161,7 +161,9 @@ class CacheEngine:
         duration = end_time - start_time
         duration *= 1000
         total_size = human_readable_size(total_size)
-        debug_pront_3(f"Done sending blocks {len(block_ids) = } ({total_size = }) to {rank = } in {duration} ms")
+        debug_pront_3(
+            f"Done sending blocks {len(block_ids) = } ({total_size = }) to {rank = } in {duration} ms"
+        )
         return
 
     def recv_blocks(self, block_ids: List[int]) -> None:
@@ -184,13 +186,17 @@ class CacheEngine:
         duration = end_time - start_time
         duration *= 1000
         total_size = human_readable_size(total_size)
-        debug_pront_3(f"Done receiving (irecv) blocks {len(block_ids) = } ({total_size = }) from {rank = } in {duration} ms")
+        debug_pront_3(
+            f"Done receiving (irecv) blocks {len(block_ids) = } ({total_size = }) from {rank = } in {duration} ms"
+        )
         for i, task in enumerate(tasks):
             task.wait()
         end_time = time.time()
         duration = end_time - start_time
         duration *= 1000
-        debug_pront_3(f"Done waiting (irecv) blocks {len(block_ids) = } ({total_size = }) from {rank = } in {duration} ms")
+        debug_pront_3(
+            f"Done waiting (irecv) blocks {len(block_ids) = } ({total_size = }) from {rank = } in {duration} ms"
+        )
         return
 
     def copy(self, src_to_dsts: Dict[int, List[int]]) -> None:

--- a/vllm/worker/cache_engine.py
+++ b/vllm/worker/cache_engine.py
@@ -148,12 +148,12 @@ class CacheEngine:
                 for j in [0, 1]:
                     a = self.gpu_cache[i][j][block_id]
                     x = torch.distributed.isend(a, dst=rank)
-                    tasks.append(x)
-                pass
-        for task in tasks:
-            debug_pront(f"Waiting for task: {task}")
-            task.wait()
-        debug_pront(f"Done sending blocks {block_ids = } to {rank = }")
+        #             tasks.append(x)
+        #         pass
+        # for task in tasks:
+        #     debug_pront(f"Waiting for task: {task}")
+        #     task.wait()
+        # debug_pront(f"Done sending blocks {block_ids = } to {rank = }")
         return
 
     def recv_blocks(self, block_ids: List[int]) -> None:

--- a/vllm/worker/cache_engine.py
+++ b/vllm/worker/cache_engine.py
@@ -141,7 +141,7 @@ class CacheEngine:
     def send_blocks(self, block_ids: List[int]) -> None:
         tasks = []
         rank = get_pipeline_model_parallel_next_rank()
-        debug_pront(f"Sending blocks {block_ids = } to {rank = }")
+        debug_pront_3(f"Sending blocks {block_ids = } to {rank = }")
         for block_id in block_ids:
             for i in range(self.num_layers):
                 debug_pront(f"Sending block: {block_id} from layer {i}")
@@ -153,13 +153,13 @@ class CacheEngine:
         # for task in tasks:
         #     debug_pront(f"Waiting for task: {task}")
         #     task.wait()
-        # debug_pront(f"Done sending blocks {block_ids = } to {rank = }")
+        debug_pront_3(f"Done sending blocks {block_ids = } to {rank = }")
         return
 
     def recv_blocks(self, block_ids: List[int]) -> None:
         tasks = []
         rank = get_pipeline_model_parallel_prev_rank()
-        debug_pront(f"Receiving blocks {block_ids = } from {rank = }")
+        debug_pront_3(f"Receiving blocks {block_ids = } from {rank = }")
         for block_id in block_ids:
             for i in range(self.num_layers):
                 debug_pront(f"Receiving block: {block_id} from layer {i}")
@@ -171,7 +171,7 @@ class CacheEngine:
         for i, task in enumerate(tasks):
             debug_pront(f"Waiting for task: {i}")
             task.wait()
-        debug_pront(f"Done receiving blocks {block_ids = } from {rank = }")
+        debug_pront_3(f"Done receiving blocks {block_ids = } from {rank = }")
         return
 
     def copy(self, src_to_dsts: Dict[int, List[int]]) -> None:

--- a/vllm/worker/cache_engine.py
+++ b/vllm/worker/cache_engine.py
@@ -90,8 +90,8 @@ class CacheEngine:
             gpu_cache.append((key_blocks, value_blocks))
 
         a, b = gpu_cache[0]
-        debug_pront_3(f"At allocate_gpu_cache(), got {a.storage() = }")
-        debug_pront_3(f"At allocate_gpu_cache(), got {b.storage() = }")
+        debug_pront_3(f"At allocate_gpu_cache(), got {a.untyped_storage() = }")
+        debug_pront_3(f"At allocate_gpu_cache(), got {b.untyped_storage() = }")
         return gpu_cache
 
     def allocate_cpu_cache(self) -> List[KVCache]:

--- a/vllm/worker/cache_engine.py
+++ b/vllm/worker/cache_engine.py
@@ -1,4 +1,5 @@
 """CacheEngine class for managing the KV cache."""
+import random
 import time
 from typing import Dict, List, Tuple
 
@@ -142,7 +143,7 @@ class CacheEngine:
     def send_blocks(self, block_ids: List[int]) -> None:
         tasks = []
         rank = get_pipeline_model_parallel_next_rank()
-        start_time = time.time()
+        start_time = time.perf_counter()
         debug_pront_3(f"Sending blocks {len(block_ids) = } to {rank = }")
         total_size = 0
         for block_id in block_ids:
@@ -157,7 +158,7 @@ class CacheEngine:
         # for task in tasks:
         #     debug_pront(f"Waiting for task: {task}")
         #     task.wait()
-        end_time = time.time()
+        end_time = time.perf_counter()
         duration = end_time - start_time
         duration *= 1000
         total_size = human_readable_size(total_size)
@@ -169,7 +170,7 @@ class CacheEngine:
     def recv_blocks(self, block_ids: List[int]) -> None:
         tasks = []
         rank = get_pipeline_model_parallel_prev_rank()
-        start_time = time.time()
+        start_time = time.perf_counter()
         # debug_pront_3(f"Receiving blocks {block_ids = } from {rank = }")
         debug_pront_3(f"Receiving blocks {len(block_ids) = } from {rank = }")
         total_size = 0
@@ -182,7 +183,7 @@ class CacheEngine:
                     total_size += tensor_size_in_bytes(a)
                     tasks.append(x)
                 pass
-        end_time = time.time()
+        end_time = time.perf_counter()
         duration = end_time - start_time
         duration *= 1000
         total_size = human_readable_size(total_size)

--- a/vllm/worker/cache_engine.py
+++ b/vllm/worker/cache_engine.py
@@ -6,6 +6,8 @@ import torch
 from vllm._C import cache_ops
 from vllm.config import CacheConfig, ModelConfig, ParallelConfig
 from vllm.logger import init_logger
+from vllm.model_executor.parallel_utils.parallel_state import get_pipeline_model_parallel_next_rank, \
+    get_pipeline_model_parallel_prev_rank
 from vllm.utils import in_wsl
 
 logger = init_logger(__name__)
@@ -132,6 +134,34 @@ class CacheEngine:
 
     def swap_out(self, src_to_dst: Dict[int, int]) -> None:
         self._swap(self.gpu_cache, self.cpu_cache, src_to_dst)
+
+    def send_blocks(self, block_ids: List[int]) -> None:
+        tasks = []
+        rank = get_pipeline_model_parallel_next_rank()
+        for block_id in block_ids:
+            for i in range(self.num_layers):
+                for j in [0, 1]:
+                    a = self.gpu_cache[i][j][block_id]
+                    x = torch.distributed.isend(a, dst=rank)
+                    tasks.append(x)
+                pass
+        for task in tasks:
+            task.wait()
+        return
+
+    def recv_blocks(self, block_ids: List[int]) -> None:
+        tasks = []
+        rank = get_pipeline_model_parallel_prev_rank()
+        for block_id in block_ids:
+            for i in range(self.num_layers):
+                for j in [0, 1]:
+                    a = self.gpu_cache[i][j][block_id]
+                    x = torch.distributed.irecv(a, src=rank)
+                    tasks.append(x)
+                pass
+        for task in tasks:
+            task.wait()
+        return
 
     def copy(self, src_to_dsts: Dict[int, List[int]]) -> None:
         key_caches = [key_cache for key_cache, _ in self.gpu_cache]

--- a/vllm/worker/cache_engine.py
+++ b/vllm/worker/cache_engine.py
@@ -88,10 +88,6 @@ class CacheEngine:
                 device="cuda",
             )
             gpu_cache.append((key_blocks, value_blocks))
-
-        a, b = gpu_cache[0]
-        debug_pront_3(f"At allocate_gpu_cache(), got {a.untyped_storage() = }")
-        debug_pront_3(f"At allocate_gpu_cache(), got {b.untyped_storage() = }")
         return gpu_cache
 
     def allocate_cpu_cache(self) -> List[KVCache]:

--- a/vllm/worker/cache_engine.py
+++ b/vllm/worker/cache_engine.py
@@ -88,6 +88,10 @@ class CacheEngine:
                 device="cuda",
             )
             gpu_cache.append((key_blocks, value_blocks))
+
+        a, b = gpu_cache[0]
+        debug_pront_3(f"At allocate_gpu_cache(), got {a.storage() = }")
+        debug_pront_3(f"At allocate_gpu_cache(), got {b.storage() = }")
         return gpu_cache
 
     def allocate_cpu_cache(self) -> List[KVCache]:

--- a/vllm/worker/cache_engine.py
+++ b/vllm/worker/cache_engine.py
@@ -8,7 +8,7 @@ from vllm.config import CacheConfig, ModelConfig, ParallelConfig
 from vllm.logger import init_logger
 from vllm.model_executor.parallel_utils.parallel_state import get_pipeline_model_parallel_next_rank, \
     get_pipeline_model_parallel_prev_rank
-from vllm.utils import in_wsl, debug_pront
+from vllm.utils import in_wsl, debug_pront, debug_pront_3
 
 logger = init_logger(__name__)
 
@@ -72,7 +72,10 @@ class CacheEngine:
     def allocate_gpu_cache(self) -> List[KVCache]:
         gpu_cache: List[KVCache] = []
         key_block_shape = self.get_key_block_shape()
+        debug_pront_3(f"At allocate_gpu_cache(), got {self.num_layers = }")
+        debug_pront_3(f"At allocate_gpu_cache(), got {key_block_shape = }")
         value_block_shape = self.get_value_block_shape()
+        debug_pront_3(f"At allocate_gpu_cache(), got {value_block_shape = }")
         for _ in range(self.num_layers):
             key_blocks = torch.empty(
                 size=(self.num_gpu_blocks, *key_block_shape),

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -387,7 +387,6 @@ class ModelRunner:
         lead_worker_rank=0,
         group=None,
     ) -> Tuple[torch.Tensor, torch.Tensor, InputMetadata, SamplingMetadata]:
-        # FIXME: (GindaChen) Does the function assume it calls on a TP-group?
         if self.is_driver_worker:
             # NOTE: We assume that all sequences in the group are all prompts or
             # all decodes.

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -204,6 +204,7 @@ class ModelRunner:
         self,
         seq_group_metadata_list: List[SequenceGroupMetadata],
     ) -> Tuple[torch.Tensor, torch.Tensor, InputMetadata]:
+        time.sleep(2)
         print(f"Inside _prepare_decode({seq_group_metadata_list=})")
         assert len(seq_group_metadata_list) > 0
         input_tokens: List[List[int]] = []
@@ -234,6 +235,7 @@ class ModelRunner:
 
                 context_len = seq_len if self.sliding_window is None else min(
                     seq_len, self.sliding_window)
+                time.sleep(2)
                 print(f"Get {min(seq_len, self.sliding_window) = }")
                 print(f"Get {context_len = }")
                 context_lens.append(context_len)

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -236,10 +236,10 @@ class ModelRunner:
 
                 context_len = seq_len if self.sliding_window is None else min(
                     seq_len, self.sliding_window)
-                time.sleep(5)
-                print(f"Get {min(seq_len, self.sliding_window) = }")
                 print(f"Get {context_len = }")
                 context_lens.append(context_len)
+                print(f"Get {context_lens = }")
+                time.sleep(5)
 
                 block_table = seq_group_metadata.block_tables[seq_id]
                 print(f"Get {block_table = }")

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -259,6 +259,7 @@ class ModelRunner:
 
         print(f"Finished iteration of the seq_group_metadata_list")
         batch_size = len(input_tokens)
+
         print(f"Get {batch_size = }")
         print(f"Get {input_tokens = }")
         print(f"Get {context_lens = }")

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -416,7 +416,7 @@ class ModelRunner:
                  subquery_lens) = self._prepare_prompt(seq_group_metadata_list)
             else:
                 print(
-                    f"With {lead_worker_rank = }, Calling prepare_input_tensors({seq_group_metadata_list=})"
+                    f"With {lead_worker_rank = }, Calling prepare_input_tensors({len(seq_group_metadata_list)=})"
                 )
                 (input_tokens, input_positions, input_metadata
                  ) = self._prepare_decode(seq_group_metadata_list)
@@ -482,7 +482,7 @@ class ModelRunner:
     ) -> Optional[SamplerOutput]:
         rank = torch.distributed.get_rank()
         print(
-            f"Worker with rank Inside execute_model({seq_group_metadata_list=}, {kv_caches=}, {lead_worker_rank=}, {group=})"
+            f"Worker with {rank = } Inside execute_model({len(seq_group_metadata_list)=}, {len(kv_caches)=}, {lead_worker_rank=}, {group=})"
         )
         input_tokens, input_positions, input_metadata, sampling_metadata = (
             self.prepare_input_tensors(

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -37,6 +37,7 @@ class ModelRunner:
         self.model_config = model_config
         self.parallel_config = parallel_config
         self.scheduler_config = scheduler_config
+        self.is_driver_worker = is_driver_worker
 
         # model_config can be None in tests/samplers/test_sampler.py.
         # FIXME(woosuk): This is a hack to make the tests work. Refactor this.
@@ -61,12 +62,12 @@ class ModelRunner:
         # cache in_wsl result
         self.in_wsl = in_wsl()
 
-    @property
-    def is_driver_worker(self):
-        # FIXME: (HACK) distinguish who is the driver worker.
-        rank = get_tensor_model_parallel_rank()
-        leader_rank = get_tensor_model_parallel_src_rank()
-        return rank == leader_rank
+    # @property
+    # def is_driver_worker(self):
+    #     # FIXME: (HACK) distinguish who is the driver worker.
+    #     rank = get_tensor_model_parallel_rank()
+    #     leader_rank = get_tensor_model_parallel_src_rank()
+    #     return rank == leader_rank
 
     def load_model(self) -> None:
         self.model = get_model(self.model_config)

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -236,7 +236,7 @@ class ModelRunner:
 
                 context_len = seq_len if self.sliding_window is None else min(
                     seq_len, self.sliding_window)
-                time.sleep(2)
+                time.sleep(5)
                 print(f"Get {min(seq_len, self.sliding_window) = }")
                 print(f"Get {context_len = }")
                 context_lens.append(context_len)

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -204,7 +204,7 @@ class ModelRunner:
         self,
         seq_group_metadata_list: List[SequenceGroupMetadata],
     ) -> Tuple[torch.Tensor, torch.Tensor, InputMetadata]:
-        time.sleep(2)
+        time.sleep(0.5)
         print(f"Inside _prepare_decode({seq_group_metadata_list=})")
         assert len(seq_group_metadata_list) > 0
         input_tokens: List[List[int]] = []
@@ -239,7 +239,7 @@ class ModelRunner:
                 print(f"Get {context_len = }")
                 context_lens.append(context_len)
                 print(f"Get {context_lens = }")
-                time.sleep(5)
+                # time.sleep(5)
 
                 block_table = seq_group_metadata.block_tables[seq_id]
                 print(f"Get {block_table = }")

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -85,7 +85,7 @@ class ModelRunner:
         self,
         seq_group_metadata_list: List[SequenceGroupMetadata],
     ) -> Tuple[torch.Tensor, torch.Tensor, InputMetadata, List[int],
-    List[int]]:
+               List[int]]:
         assert len(seq_group_metadata_list) > 0
         input_tokens: List[List[int]] = []
         input_positions: List[List[int]] = []
@@ -339,7 +339,7 @@ class ModelRunner:
 
                 categorized_sample_indices[
                     sampling_params.sampling_type].append(
-                    categorized_sample_indices_start_idx)
+                        categorized_sample_indices_start_idx)
                 categorized_sample_indices_start_idx += 1
 
                 if sampling_params.prompt_logprobs is not None:
@@ -358,8 +358,8 @@ class ModelRunner:
 
                 categorized_sample_indices[
                     sampling_params.sampling_type].extend(
-                    range(categorized_sample_indices_start_idx,
-                          categorized_sample_indices_start_idx + num_seqs))
+                        range(categorized_sample_indices_start_idx,
+                              categorized_sample_indices_start_idx + num_seqs))
                 categorized_sample_indices_start_idx += num_seqs
 
         selected_token_indices = _async_h2d(selected_token_indices,
@@ -423,7 +423,7 @@ class ModelRunner:
                 "block_tables": input_metadata.block_tables,
                 "use_cuda_graph": input_metadata.use_cuda_graph,
                 "selected_token_indices":
-                    sampling_metadata.selected_token_indices,
+                sampling_metadata.selected_token_indices,
             }
             broadcast_tensor_dict(metadata_dict,
                                   src=lead_worker_rank,
@@ -467,7 +467,8 @@ class ModelRunner:
         debug_pront_3(
             f"Worker with {rank = } Inside execute_model({len(seq_group_metadata_list)=}, {len(kv_caches)=}, {lead_worker_rank=}, {group=})"
         )
-        debug_pront_3(f"Executing the model with {len(seq_group_metadata_list)}")
+        debug_pront_3(
+            f"Executing the model with {len(seq_group_metadata_list)}")
         start_time = time.perf_counter()
         input_tokens, input_positions, input_metadata, sampling_metadata = (
             self.prepare_input_tensors(
@@ -475,7 +476,9 @@ class ModelRunner:
                 lead_worker_rank=lead_worker_rank,
                 group=group,
             ))
-        debug_pront_3(f"prepare_input_tensors() took {((time.perf_counter() - start_time) * 1000):.2f} ms")
+        debug_pront_3(
+            f"prepare_input_tensors() took {((time.perf_counter() - start_time) * 1000):.2f} ms"
+        )
 
         start_time = time.perf_counter()
         # Execute the model.
@@ -492,8 +495,7 @@ class ModelRunner:
         )
         debug_pront_3(
             f"model_executable() with {input_tokens.shape = } and {len(kv_caches) = } took "
-            f"{((time.perf_counter() - start_time) * 1000):.2f} ms"
-        )
+            f"{((time.perf_counter() - start_time) * 1000):.2f} ms")
 
         # Sample the next token.
         start_time = time.perf_counter()
@@ -501,7 +503,9 @@ class ModelRunner:
             hidden_states=hidden_states,
             sampling_metadata=sampling_metadata,
         )
-        debug_pront_3(f"model.sample() took {((time.perf_counter() - start_time) * 1000):.2f} ms")
+        debug_pront_3(
+            f"model.sample() took {((time.perf_counter() - start_time) * 1000):.2f} ms"
+        )
         return output
 
     @torch.inference_mode()

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -230,6 +230,7 @@ class ModelRunner:
 
                 seq_len = seq_data.get_len()
                 print(f"Get {seq_len = }")
+                print(f"Get {self.sliding_window = }")
                 position = seq_len - 1
                 input_positions.append([position])
 

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -449,13 +449,15 @@ class ModelRunner:
         self,
         seq_group_metadata_list: Optional[List[SequenceGroupMetadata]],
         kv_caches: List[Tuple[torch.Tensor, torch.Tensor]],
+        lead_worker_rank=0,
+        group=None,
     ) -> Optional[SamplerOutput]:
 
         input_tokens, input_positions, input_metadata, sampling_metadata = (
             self.prepare_input_tensors(
                 seq_group_metadata_list,
-                lead_worker_rank=get_tensor_model_parallel_src_rank(),
-                group=get_tensor_model_parallel_group(),
+                lead_worker_rank=lead_worker_rank,
+                group=group,
             ))
         # Execute the model.
         if input_metadata.use_cuda_graph:

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -495,7 +495,7 @@ class ModelRunner:
                 lead_worker_rank=lead_worker_rank,
                 group=group,
             ))
-        debug_pront_3(f"prepare_input_tensors() took {time.perf_counter() - start_time:.3f} secs")
+        debug_pront_3(f"prepare_input_tensors() took {((time.perf_counter() - start_time) * 1000):.2f} ms")
 
         start_time = time.perf_counter()
         # Execute the model.
@@ -510,7 +510,7 @@ class ModelRunner:
             kv_caches=kv_caches,
             input_metadata=input_metadata,
         )
-        debug_pront_3(f"model_executable() took {time.perf_counter() - start_time:.3f} secs")
+        debug_pront_3(f"model_executable() took {((time.perf_counter() - start_time) * 1000):.2f} ms")
 
         # Sample the next token.
         start_time = time.perf_counter()
@@ -518,7 +518,7 @@ class ModelRunner:
             hidden_states=hidden_states,
             sampling_metadata=sampling_metadata,
         )
-        debug_pront_3(f"model.sample() took {time.perf_counter() - start_time:.3f} secs")
+        debug_pront_3(f"model.sample() took {((time.perf_counter() - start_time) * 1000):.2f} ms")
         return output
 
     @torch.inference_mode()

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -484,7 +484,7 @@ class ModelRunner:
         group=None,
     ) -> Optional[SamplerOutput]:
         rank = torch.distributed.get_rank()
-        debug_pront(
+        debug_pront_3(
             f"Worker with {rank = } Inside execute_model({len(seq_group_metadata_list)=}, {len(kv_caches)=}, {lead_worker_rank=}, {group=})"
         )
         debug_pront_3(f"Executing the model with {len(seq_group_metadata_list)}")

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -226,6 +226,8 @@ class Worker:
 
         # If there is no input, we don't need to execute the model.
         num_seq_groups = len(seq_group_metadata_list)
+        print(f"Worker {self.rank} executes model with {seq_group_metadata_list = }")
+        print(f"Worker {self.rank} executes model with {num_seq_groups = }")
         if num_seq_groups == 0:
             return {}
 

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -48,11 +48,8 @@ class Worker:
             assert self.rank == 0, "The driver worker must have rank 0."
 
         # FIXME: Assume the first worker in TP-group is the lead worker.
-        is_lead_worker = get_tensor_model_parallel_rank()
-        print(f"Worker {self.rank} has {is_lead_worker = }")
-        self.is_lead_worker = is_lead_worker
         self.model_runner = ModelRunner(model_config, parallel_config,
-                                        scheduler_config, is_lead_worker)
+                                        scheduler_config)
         # Uninitialized cache engine. Will be initialized by
         # self.init_cache_engine().
         self.cache_config = None

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -58,7 +58,7 @@ class Worker:
         self.pre_execute_model_data = None
 
         # FIXME: (hack) SHOULD NOT BE IN MASTER!
-        def hack_store_data(self, data):
+        def hack_store_data(data):
             """Store data in the _pre_execute_model_data. Handler for passing data
             from driver node to the other workers."""
             self.pre_execute_model_data = data

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -212,10 +212,10 @@ class Worker:
                                recv_blocks=recv_blocks)
 
         # Perform cache swapping
-        num_seq_groups = len(seq_group_metadata_list)
         self.cache_swap(blocks_to_swap_in, blocks_to_swap_out, blocks_to_copy)
 
         # If there is no input, we don't need to execute the model.
+        num_seq_groups = len(seq_group_metadata_list)
         if num_seq_groups == 0:
             return {}
 

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -49,7 +49,8 @@ class Worker:
 
         # FIXME: Assume the first worker in TP-group is the lead worker.
         self.model_runner = ModelRunner(model_config, parallel_config,
-                                        scheduler_config, self.is_driver_worker)
+                                        scheduler_config,
+                                        self.is_driver_worker)
         # Uninitialized cache engine. Will be initialized by
         # self.init_cache_engine().
         self.cache_config = None

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -226,6 +226,8 @@ class Worker:
         # Execute the model in the same tensor-parallel group.
         lead_worker_rank = get_tensor_model_parallel_src_rank()
         group = get_tensor_model_parallel_group()
+        print(f"Worker {self.rank} executes model with {lead_worker_rank = } "
+              f"and {torch.distributed.get_process_group_ranks(group) = }")
 
         output = self.model_runner.execute_model(
             seq_group_metadata_list,

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -169,7 +169,9 @@ class Worker:
                 event.wait()
 
     # FIXME: (hack) Hack the way out to identify prefill/decode role of the worker.
-    def transfer_kv_cache(self, send_blocks: List[int] = None, recv_blocks: List[int] = None):
+    def transfer_kv_cache(self,
+                          send_blocks: List[int] = None,
+                          recv_blocks: List[int] = None):
         """Migrate KV cache from prefill to decode. If the worker is
         responsible for prefill, then send; otherwise, receive.
         """

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -200,8 +200,6 @@ class Worker:
             self.cache_engine.send_blocks(send_blocks)
         else:
             self.cache_engine.recv_blocks(recv_blocks)
-
-        torch.cuda.synchronize()
         return
 
     # FIXME: (hack) SHOULD NOT BE IN MASTER!

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -169,7 +169,7 @@ class Worker:
                 event.wait()
 
     # FIXME: (hack) Hack the way out to identify prefill/decode role of the worker.
-    def transfer_kv_cache(self, blocks_to_transfer: List[int] = None):
+    def transfer_kv_cache(self, send_blocks: List[int] = None, recv_blocks: List[int] = None):
         """Migrate KV cache from prefill to decode. If the worker is
         responsible for prefill, then send; otherwise, receive.
         """
@@ -180,9 +180,9 @@ class Worker:
             return leader_rank == rank
 
         if is_prefill_worker():
-            self.cache_engine.send_blocks(blocks_to_transfer)
+            self.cache_engine.send_blocks(send_blocks)
         else:
-            self.cache_engine.recv_blocks(blocks_to_transfer)
+            self.cache_engine.recv_blocks(recv_blocks)
 
         torch.cuda.synchronize()
         return

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -128,6 +128,9 @@ class Worker:
         self.gpu_cache = self.cache_engine.gpu_cache
         self.model_runner.set_block_size(self.cache_engine.block_size)
 
+    def execute_lambda(self, lambda_fn, *args, **kwargs):
+        return lambda_fn(self, *args, **kwargs)
+
     def warm_up_model(self) -> None:
         if not self.model_config.enforce_eager:
             self.model_runner.capture_model(self.gpu_cache)

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -1,5 +1,6 @@
 """A GPU worker class."""
 import os
+from time import sleep
 from typing import Dict, List, Optional, Tuple
 
 import torch
@@ -243,6 +244,7 @@ class Worker:
               f"{self.rank = }\n"
               f"{self.is_driver_worker = }\n"
               f"{self.model_runner.is_driver_worker = }\n")
+        sleep(1)
 
         output = self.model_runner.execute_model(
             seq_group_metadata_list,

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -179,7 +179,9 @@ class Worker:
         if not send_blocks or not recv_blocks:
             return
 
-        print(f"Worker {self.rank} executes transfer_kv_cache with {send_blocks = } and {recv_blocks = }")
+        print(
+            f"Worker {self.rank} executes transfer_kv_cache with {send_blocks = } and {recv_blocks = }"
+        )
 
         def is_prefill_worker():
             leader_rank = get_pipeline_model_parallel_first_rank()

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -16,6 +16,7 @@ from vllm.model_executor.parallel_utils.parallel_state import (
     get_tensor_model_parallel_group, get_tensor_model_parallel_rank,
     get_pipeline_model_parallel_first_rank, ensure_model_parallel_initialized)
 from vllm.sequence import SamplerOutput, SequenceGroupMetadata
+from vllm.utils import debug_slept
 from vllm.worker.cache_engine import CacheEngine
 from vllm.worker.model_runner import ModelRunner
 
@@ -244,7 +245,7 @@ class Worker:
               f"{self.rank = }\n"
               f"{self.is_driver_worker = }\n"
               f"{self.model_runner.is_driver_worker = }\n")
-        sleep(1)
+        debug_slept(1)
 
         output = self.model_runner.execute_model(
             seq_group_metadata_list,

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -176,7 +176,7 @@ class Worker:
         responsible for prefill, then send; otherwise, receive.
         """
 
-        if not send_blocks and not recv_blocks:
+        if not send_blocks or not recv_blocks:
             return
 
         def is_prefill_worker():

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -186,11 +186,7 @@ class Worker:
         blocks_to_copy: Optional[Dict[int, List[int]]] = None,
     ) -> Optional[SamplerOutput]:
         # FIXME: (hack) pre-execution metadata from driver node to this worker.
-        data = self.pre_execute_model_data
-        num_seq_groups = data["num_seq_groups"]
-        blocks_to_swap_in = data["blocks_to_swap_in"]
-        blocks_to_swap_out = data["blocks_to_swap_out"]
-        blocks_to_copy = data["blocks_to_copy"]
+        num_seq_groups = len(seq_group_metadata_list)
         self.cache_swap(blocks_to_swap_in, blocks_to_swap_out, blocks_to_copy)
 
         # If there is no input, we don't need to execute the model.

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -231,20 +231,22 @@ class Worker:
         debug_pront(
             f"Worker {self.rank} executes model with {seq_group_metadata_list = }"
         )
-        debug_pront(f"Worker {self.rank} executes model with {num_seq_groups = }")
+        debug_pront(
+            f"Worker {self.rank} executes model with {num_seq_groups = }")
         if num_seq_groups == 0:
             return {}
 
         # Execute the model in the same tensor-parallel group.
         lead_worker_rank = get_tensor_model_parallel_src_rank()
         group = get_tensor_model_parallel_group()
-        debug_pront(f"Worker {self.rank} executes model with {lead_worker_rank = } "
-              f"and {torch.distributed.get_process_group_ranks(group) = }")
+        debug_pront(
+            f"Worker {self.rank} executes model with {lead_worker_rank = } "
+            f"and {torch.distributed.get_process_group_ranks(group) = }")
         debug_pront(f"Worker {self.rank} property: \n"
-              f"{torch.distributed.get_rank() = }\n"
-              f"{self.rank = }\n"
-              f"{self.is_driver_worker = }\n"
-              f"{self.model_runner.is_driver_worker = }\n")
+                    f"{torch.distributed.get_rank() = }\n"
+                    f"{self.rank = }\n"
+                    f"{self.is_driver_worker = }\n"
+                    f"{self.model_runner.is_driver_worker = }\n")
         debug_slept(1)
 
         output = self.model_runner.execute_model(

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -55,7 +55,15 @@ class Worker:
         self.gpu_cache = None
 
         # FIXME: (hack) SHOULD NOT BE IN MASTER!
-        self._pre_execute_model_data = None
+        self.pre_execute_model_data = None
+
+        # FIXME: (hack) SHOULD NOT BE IN MASTER!
+        def hack_store_data(self, data):
+            """Store data in the _pre_execute_model_data. Handler for passing data
+            from driver node to the other workers."""
+            self.pre_execute_model_data = data
+
+        self.hack_store_data = hack_store_data
 
     def init_model(self) -> None:
         # torch.distributed.all_reduce does not free the input tensor until
@@ -168,10 +176,6 @@ class Worker:
                 event.wait()
 
     # FIXME: (hack) SHOULD NOT BE IN MASTER!
-    def _hack_store_data(self, data):
-        """Store data in the _pre_execute_model_data. Handler for passing data
-        from driver node to the other workers."""
-        self._pre_execute_model_data = data
 
     @torch.inference_mode()
     def execute_model(
@@ -182,7 +186,7 @@ class Worker:
         blocks_to_copy: Optional[Dict[int, List[int]]] = None,
     ) -> Optional[SamplerOutput]:
         # FIXME: (hack) pre-execution metadata from driver node to this worker.
-        data = self._pre_execute_model_data
+        data = self.pre_execute_model_data
         num_seq_groups = data["num_seq_groups"]
         blocks_to_swap_in = data["blocks_to_swap_in"]
         blocks_to_swap_out = data["blocks_to_swap_out"]

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -226,7 +226,9 @@ class Worker:
 
         # If there is no input, we don't need to execute the model.
         num_seq_groups = len(seq_group_metadata_list)
-        print(f"Worker {self.rank} executes model with {seq_group_metadata_list = }")
+        print(
+            f"Worker {self.rank} executes model with {seq_group_metadata_list = }"
+        )
         print(f"Worker {self.rank} executes model with {num_seq_groups = }")
         if num_seq_groups == 0:
             return {}

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -16,7 +16,7 @@ from vllm.model_executor.parallel_utils.parallel_state import (
     get_tensor_model_parallel_group, get_tensor_model_parallel_rank,
     get_pipeline_model_parallel_first_rank, ensure_model_parallel_initialized)
 from vllm.sequence import SamplerOutput, SequenceGroupMetadata
-from vllm.utils import debug_slept
+from vllm.utils import debug_slept, debug_pront
 from vllm.worker.cache_engine import CacheEngine
 from vllm.worker.model_runner import ModelRunner
 
@@ -187,7 +187,7 @@ class Worker:
         if not send_blocks or not recv_blocks:
             return
 
-        print(
+        debug_pront(
             f"Worker {self.rank} executes transfer_kv_cache with {send_blocks = } and {recv_blocks = }"
         )
 
@@ -228,19 +228,19 @@ class Worker:
 
         # If there is no input, we don't need to execute the model.
         num_seq_groups = len(seq_group_metadata_list)
-        print(
+        debug_pront(
             f"Worker {self.rank} executes model with {seq_group_metadata_list = }"
         )
-        print(f"Worker {self.rank} executes model with {num_seq_groups = }")
+        debug_pront(f"Worker {self.rank} executes model with {num_seq_groups = }")
         if num_seq_groups == 0:
             return {}
 
         # Execute the model in the same tensor-parallel group.
         lead_worker_rank = get_tensor_model_parallel_src_rank()
         group = get_tensor_model_parallel_group()
-        print(f"Worker {self.rank} executes model with {lead_worker_rank = } "
+        debug_pront(f"Worker {self.rank} executes model with {lead_worker_rank = } "
               f"and {torch.distributed.get_process_group_ranks(group) = }")
-        print(f"Worker {self.rank} property: \n"
+        debug_pront(f"Worker {self.rank} property: \n"
               f"{torch.distributed.get_rank() = }\n"
               f"{self.rank = }\n"
               f"{self.is_driver_worker = }\n"

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -208,7 +208,8 @@ class Worker:
         # FIXME: (hack) pre-execution metadata from driver node to this worker.
 
         # Transfer blocks from prefill worker to this worker (if any)
-        self.transfer_kv_cache(send_blocks=send_blocks, recv_blocks=recv_blocks)
+        self.transfer_kv_cache(send_blocks=send_blocks,
+                               recv_blocks=recv_blocks)
 
         # Perform cache swapping
         num_seq_groups = len(seq_group_metadata_list)

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -179,6 +179,8 @@ class Worker:
         if not send_blocks or not recv_blocks:
             return
 
+        print(f"Worker {self.rank} executes transfer_kv_cache with {send_blocks = } and {recv_blocks = }")
+
         def is_prefill_worker():
             leader_rank = get_pipeline_model_parallel_first_rank()
             rank = torch.distributed.get_rank()

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -190,6 +190,7 @@ class Worker:
         num_seq_groups = len(seq_group_metadata_list)
         self.cache_swap(blocks_to_swap_in, blocks_to_swap_out, blocks_to_copy)
 
+
         # If there is no input, we don't need to execute the model.
         if num_seq_groups == 0:
             return {}

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -49,24 +49,13 @@ class Worker:
 
         # FIXME: Assume the first worker in TP-group is the lead worker.
         self.model_runner = ModelRunner(model_config, parallel_config,
-                                        scheduler_config)
+                                        scheduler_config, self.is_driver_worker)
         # Uninitialized cache engine. Will be initialized by
         # self.init_cache_engine().
         self.cache_config = None
         self.cache_engine: 'CacheEngine' = None
         self.cache_events = None
         self.gpu_cache = None
-
-        # FIXME: (hack) SHOULD NOT BE IN MASTER!
-        self.pre_execute_model_data = None
-
-        # FIXME: (hack) SHOULD NOT BE IN MASTER!
-        def hack_store_data(data):
-            """Store data in the _pre_execute_model_data. Handler for passing data
-            from driver node to the other workers."""
-            self.pre_execute_model_data = data
-
-        self.hack_store_data = hack_store_data
 
     def init_model(self) -> None:
         # torch.distributed.all_reduce does not free the input tensor until

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -202,8 +202,8 @@ class Worker:
         blocks_to_swap_out: Optional[Dict[int, int]] = None,
         blocks_to_copy: Optional[Dict[int, List[int]]] = None,
         # TODO: Decouple data transfer from the send/recv logic.
-        send_blocks=None,
-        recv_blocks=None,
+        send_blocks: List[int] = None,
+        recv_blocks: List[int] = None,
     ) -> Optional[SamplerOutput]:
         # FIXME: (hack) pre-execution metadata from driver node to this worker.
 

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -13,8 +13,7 @@ from vllm.model_executor.parallel_utils.communication_op import (
 from vllm.model_executor.parallel_utils.parallel_state import (
     initialize_model_parallel, get_tensor_model_parallel_src_rank,
     get_tensor_model_parallel_group, get_tensor_model_parallel_rank,
-    get_pipeline_model_parallel_first_rank,
-    ensure_model_parallel_initialized)
+    get_pipeline_model_parallel_first_rank, ensure_model_parallel_initialized)
 from vllm.sequence import SamplerOutput, SequenceGroupMetadata
 from vllm.worker.cache_engine import CacheEngine
 from vllm.worker.model_runner import ModelRunner


### PR DESCRIPTION
**Description**

Make Prefill Disaggregation running on vLLM as a prototype


**Bug Fix, Optimization, and Missing Correctness Criteria**
- (Bug) Off-by-one error or duplicate one token: When transferring KV cache from prefill to decode, the "generated token" didn't get forwarded, but decode uses it to compute. This creates some error. If we instead cut the output token from the sequence group, the stream will output one extra token at the start... (right now we are having "duplicate one token" for correctness)
- (Correctness) KV cache content validation.
- (Correctness) Generated text compared to main version (but can we get exact same output if random state is not sync?)
- (Optimization) KV cache transfer and release logic. For now, prefill is blocked until decode confirms KV cache transfer completes. I haven't measured the overhead yet.
- (Optimization) KV cache structure: Can we also batch transfer each "layer"?

**Test suite**
```bash
python examples/offline_async_distserve.py
python examples/offline_async_distserve_2.py # ... some bug in the top-level script that early terminate, but basically works
```

**Major changes**
- `DistScheduler` that encompasses prefill / decode scheduler
- In `_AsyncLLMEngine` and `AsyncLLMEngine`, introduce `step_dist_async` for async execution.


**Next Step: Proposed Change (for better architecture)**
- KV cache transfer should not block prefill task (once prefill has `isend` the caches)
- 
- Refactor `Scheduler` logic to ease-up the cranky transfer logic.